### PR TITLE
extract constants, and manager redis-cache connection in own file

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,10 +7,8 @@ const app = express();
 const server = http.createServer(app);
 const headers = require("./middleware/headers");
 const podname = process.env.podname;
-const redis = require("redis-promise");
+const redisCache = require("./redis-cache")
 const redisOTP = require("./redis-otp/datastore");
-const gkeHostname = "ts-redis-master";
-const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : gkeHostname;
 const credentials = require("./credentials");
 const timelines = require("./timelines");
 
@@ -34,14 +32,14 @@ const start = ()=>{
 
     console.log(`server is listening on ${port}`);
 
-    redis.initdb(null, redisHost);
+    redisCache.initdb(null);
     redisOTP.initdb(null);
   })
 };
 
 const stop = ()=>{
+  redisCache.close();
   redisOTP.close();
-  redis.close();
   server.close();
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
 module.exports = {
   defaultPort: 80,
   defaultTweetCount: 25,
-  numberOfCachedTweets: 100
+  numberOfCachedTweets: 100,
+  redisCacheHostname: "ts-redis-master",
+  redisOtpHostname: "otp-redis-master"
 };

--- a/src/redis-cache/index.js
+++ b/src/redis-cache/index.js
@@ -1,0 +1,13 @@
+const config = require("../config");
+const redis = require("redis-promise");
+
+const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : config.redisCacheHostname;
+
+module.exports = {
+  initdb(dbclient = null) {
+    redis.initdb(dbclient, redisHost);
+  },
+  close() {
+    redis.close();
+  }
+};

--- a/src/redis-otp/datastore.js
+++ b/src/redis-otp/datastore.js
@@ -1,7 +1,8 @@
+const config = require("../config");
 const util = require("util");
 const redis = require("redis");
-const gkeHostname = "otp-redis-master";
-const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : gkeHostname;
+
+const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : config.redisOtpHostname;
 
 let client = null;
 let promisified = ["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "exists", "incr"];


### PR DESCRIPTION
## Description
Refactored redis connection to redis-cache before adding new redis related code.

## Motivation and Context
- redis-otp finely encapsulates details for connecting to oauth token's provider Redis; this PR does something similar to the cache Redis ( as redis-cache ) as the next PRs will be working with that.
- redis-otp and current Redis code weren't reading the redis service name from configuration, so this PR extracts it to config.

## How Has This Been Tested?
Automated tests work ok.
Manual requests still work ok: http://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RiseVision&count=10

## Release Plan:
Not in production

#### Release Checklist Items Skipped?
N/A
