### PR TITLE
Feature/prevent concurrent loads of username

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
 module.exports = {
   BAD_REQUEST_ERROR: 400,
   FORBIDDEN_ERROR: 403,
+  CONFLICT_ERROR: 409,
+  CONFLICT_ERROR_MESSAGE: "Another request is already loading user timeline. Please retry in a few seconds.",
   SERVER_ERROR: 500
 };

--- a/src/redis-cache/api.js
+++ b/src/redis-cache/api.js
@@ -2,11 +2,11 @@ const redis = require("redis-promise");
 
 const statusKeyFor = username => `${ username }:status`;
 
-const asJSON = value => value ? JSON.parse(value) : null;
+const parseJSON = value => value ? JSON.parse(value) : null;
 
 const getStatusFor = username => {
   return redis.getString(statusKeyFor(username))
-  .then(asJSON);
+  .then(parseJSON);
 };
 
 const saveStatus = (username, status) => {

--- a/src/redis-cache/api.js
+++ b/src/redis-cache/api.js
@@ -1,0 +1,14 @@
+const redis = require("redis-promise");
+
+const statusKeyFor = username => `${ username }:status`;
+
+const asJSON = value => value ? JSON.parse(value) : null;
+
+const getStatusFor = username => {
+  return redis.getString(statusKeyFor(username))
+  .then(asJSON);
+};
+
+module.exports = {
+  getStatusFor
+};

--- a/src/redis-cache/api.js
+++ b/src/redis-cache/api.js
@@ -9,6 +9,13 @@ const getStatusFor = username => {
   .then(asJSON);
 };
 
+const saveStatus = (username, status) => {
+  const value = JSON.stringify(status);
+
+  return redis.setString(statusKeyFor(username), value);
+};
+
 module.exports = {
-  getStatusFor
+  getStatusFor,
+  saveStatus
 };

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -82,7 +82,7 @@ const requestRemoteUserTimeline = (query, res, credentials) => {
   });
 };
 
-const getUserTimeline = (query, res, credentials) => {
+const getTweets = (query, res, credentials) => {
   return cache.getStatusFor(query.username)
   .then(status => {
     query.status = status || {};
@@ -100,7 +100,7 @@ const handleGetTweetsRequest = (req, res) => {
   .then(query => {
     return oauthTokenProvider.getCredentials(req)
     .then(credentials => {
-      return getUserTimeline(query, res, credentials)
+      return getTweets(query, res, credentials)
       .catch(error => logAndSendError(res, error, SERVER_ERROR));
     })
     .catch(error => logAndSendError(res, error, FORBIDDEN_ERROR));

--- a/test/unit/redis-cache.tests.js
+++ b/test/unit/redis-cache.tests.js
@@ -1,0 +1,38 @@
+const assert = require("assert");
+const simple = require("simple-mock");
+const api = require("../../src/redis-cache/api");
+const redis = require("redis-promise");
+
+describe("redis-cache/api", ()=>{
+
+  afterEach(()=>{
+    simple.restore();
+  });
+
+  it("should get the status object", ()=>{
+    const storedStatus = {
+      loading: false
+    };
+
+    simple.mock(redis, "getString").resolveWith(JSON.stringify(storedStatus));
+
+    return api.getStatusFor('risevision').then(status => {
+      assert.deepEqual(status, storedStatus);
+
+      assert.equal(redis.getString.callCount, 1);
+      assert.equal(redis.getString.lastCall.args[0], "risevision:status");
+    });
+  });
+
+  it("should return null if there is no status stored", ()=>{
+    simple.mock(redis, "getString").resolveWith(null);
+
+    return api.getStatusFor('risevision').then(status => {
+      assert(status === null);
+
+      assert.equal(redis.getString.callCount, 1);
+      assert.equal(redis.getString.lastCall.args[0], "risevision:status");
+    });
+  });
+
+});

--- a/test/unit/redis-cache.tests.js
+++ b/test/unit/redis-cache.tests.js
@@ -5,33 +5,55 @@ const redis = require("redis-promise");
 
 describe("redis-cache/api", ()=>{
 
+  beforeEach(()=>{
+    simple.mock(redis, "setString").resolveWith();
+  });
+
   afterEach(()=>{
     simple.restore();
   });
 
-  it("should get the status object", ()=>{
-    const storedStatus = {
-      loading: false
-    };
+  describe("getStatusFor", ()=>{
+    it("should get the status object", ()=>{
+      const storedStatus = {
+        loading: false
+      };
 
-    simple.mock(redis, "getString").resolveWith(JSON.stringify(storedStatus));
+      simple.mock(redis, "getString").resolveWith(JSON.stringify(storedStatus));
 
-    return api.getStatusFor('risevision').then(status => {
-      assert.deepEqual(status, storedStatus);
+      return api.getStatusFor('risevision').then(status => {
+        assert.deepEqual(status, storedStatus);
 
-      assert.equal(redis.getString.callCount, 1);
-      assert.equal(redis.getString.lastCall.args[0], "risevision:status");
+        assert.equal(redis.getString.callCount, 1);
+        assert.equal(redis.getString.lastCall.args[0], "risevision:status");
+      });
+    });
+
+    it("should return null if there is no status stored", ()=>{
+      simple.mock(redis, "getString").resolveWith(null);
+
+      return api.getStatusFor('risevision').then(status => {
+        assert(status === null);
+
+        assert.equal(redis.getString.callCount, 1);
+        assert.equal(redis.getString.lastCall.args[0], "risevision:status");
+      });
     });
   });
 
-  it("should return null if there is no status stored", ()=>{
-    simple.mock(redis, "getString").resolveWith(null);
+  describe("saveStatus", ()=>{
+    it("should save the status object", ()=>{
+      const status = {
+        loading: false
+      };
 
-    return api.getStatusFor('risevision').then(status => {
-      assert(status === null);
+      return api.saveStatus('risevision', status).then(() => {
+        assert.equal(redis.setString.callCount, 1);
+        assert.equal(redis.setString.lastCall.args[0], "risevision:status");
 
-      assert.equal(redis.getString.callCount, 1);
-      assert.equal(redis.getString.lastCall.args[0], "risevision:status");
+        const value = redis.setString.lastCall.args[1];
+        assert.deepEqual(JSON.parse(value), status);
+      });
     });
   });
 

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -32,7 +32,8 @@ describe("Timelines", () => {
       json: simple.stub()
     }
 
-    simple.mock(cache, "getStatusFor").resolveWith({loading: false})
+    simple.mock(cache, "getStatusFor").resolveWith({loading: false});
+    simple.mock(cache, "saveStatus").resolveWith();
     simple.mock(oauthTokenProvider, "getCredentials").resolveWith({});
   });
 

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -23,7 +23,7 @@ describe("Timelines", () => {
     req = {
       query: {
         companyId: "test",
-        username: "RiseVision"
+        username: "risevision"
       }
     };
     res = {
@@ -144,6 +144,8 @@ describe("Timelines", () => {
 
         assert(res.send.called);
         assert.equal(res.send.lastCall.args[0], CONFLICT_ERROR_MESSAGE);
+
+        assert(!cache.saveStatus.called);
       });
     });
 
@@ -159,6 +161,16 @@ describe("Timelines", () => {
 
         assert(res.send.called);
         assert.equal(res.send.lastCall.args[0], "Network error.");
+
+        assert.equal(cache.saveStatus.callCount, 2);
+
+        // Started loading
+        assert.equal(cache.saveStatus.calls[0].args[0], "risevision");
+        assert(cache.saveStatus.calls[0].args[1].loading);
+
+        // Stopped loading
+        assert.equal(cache.saveStatus.calls[1].args[0], "risevision");
+        assert(!cache.saveStatus.calls[1].args[1].loading);
       });
     });
 
@@ -174,6 +186,16 @@ describe("Timelines", () => {
 
         assert(!res.status.called);
         assert(!res.send.called);
+
+        assert.equal(cache.saveStatus.callCount, 2);
+
+        // Started loading
+        assert.equal(cache.saveStatus.calls[0].args[0], "risevision");
+        assert(cache.saveStatus.calls[0].args[1].loading);
+
+        // Stopped loading
+        assert.equal(cache.saveStatus.calls[1].args[0], "risevision");
+        assert(!cache.saveStatus.calls[1].args[1].loading);
       });
     });
 


### PR DESCRIPTION
## Description
Turn on loading before requesting remote tweets, and turn of after.
Send error if a requests comes to a username with loading flag on.

## Motivation and Context
Implementation of get-tweets design.

Some pieces are still missing such as cached tweets and expiration of loading flag.

## How Has This Been Tested?
New unit tests cover the different scenarios and check postconditions.

Manual tests:

- username with loading flag up - sends conflict error ( I produced it by commenting turn off code and calling ) - http://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RiseVision&count=10

- other username that has loading flag off - http://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=twitter&count=10

The actual concurrency conflict with multiple simultaneous calls may be difficult to produce.

## Release Plan:
Not in production

#### Release Checklist Items Skipped?
N/A
