### PR TITLE
Feature/return 403 on invalid credentials

### DIFF
--- a/src/credentials/index.js
+++ b/src/credentials/index.js
@@ -38,11 +38,12 @@ const handleVerifyCredentialsRequest = (req, res) => {
 
       handleError(res, error, "Error when verifying credentials");
     });
-}
+};
 
 const isExpectedError = err => {
-  return err.message && (err.message.includes("No credentials for") || err.message === "Invalid or expired token.");
-}
+  return (err.message && err.message.includes("No credentials for")) ||
+    twitter.isInvalidOrExpiredTokenError(err);
+};
 
 module.exports = {
   handleVerifyCredentialsRequest

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -76,6 +76,14 @@ const returnTimeline = (query, res, timeline) => {
   res.json({tweets});
 };
 
+const handleTwitterApiCallError = (res, error) => {
+  if(twitter.isInvalidOrExpiredTokenError(error)) {
+    return logAndSendError(res, error, FORBIDDEN_ERROR);
+  }
+
+  logAndSendError(res, error, SERVER_ERROR);
+};
+
 const requestRemoteUserTimeline = (query, res, credentials) => {
   return saveLoadingFlag(query, true)
   .then(() => {
@@ -86,7 +94,7 @@ const requestRemoteUserTimeline = (query, res, credentials) => {
     })
     .catch(error => {
       return saveLoadingFlag(query, false)
-      .then(() => logAndSendError(res, error, SERVER_ERROR));
+      .then(() => handleTwitterApiCallError(res, error));
     });
   });
 };

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -42,7 +42,13 @@ const invokeEndpoint = (clientCredentials, endpoint, args) => {
     });
 };
 
+
+const isInvalidOrExpiredTokenError = error => {
+  return error.message && error.message === "Invalid or expired token.";
+};
+
 module.exports = {
+  isInvalidOrExpiredTokenError,
   getUserTimeline,
   verifyCredentials
 };

--- a/test/unit/twitter.tests.js
+++ b/test/unit/twitter.tests.js
@@ -9,6 +9,30 @@ describe("Twitter", () => {
     simple.restore();
   });
 
+  describe("isInvalidOrExpiredTokenError", () => {
+    it("should recognize invalid or expired token error", () => {
+      const result = twitter.isInvalidOrExpiredTokenError({
+        message: "Invalid or expired token."
+      });
+
+      assert(result);
+    });
+
+    it("should not recognize invalid or expired token error on other message string", () => {
+      const result = twitter.isInvalidOrExpiredTokenError({
+        message: "Another error."
+      });
+
+      assert(!result);
+    });
+
+    it("should not recognize invalid or expired token error when there is no message string", () => {
+      const result = twitter.isInvalidOrExpiredTokenError({});
+
+      assert(!result);
+    });
+  });
+
   describe("verifyCredentials", () => {
     it("should resolve to true on successful invocation", (done) => {
       simple.mock(Twitter.prototype, "get").resolveWith({});


### PR DESCRIPTION
## Description
An invalid token error on Twitter API should result on a 403 error on get-tweets call.

## Motivation and Context
Part of the endpoint design.

The invalid token error recognition function was extracted to a function so it could be reused from timelines code.

## How Has This Been Tested?
A call with expired token now returns a 403 error instead of 500: http://services-stage.risevision.com/twitter/get-tweets?companyId=87977ab8-38b6-47fb-ad5e-256b8cc4b46d&username=RiseVision

Unit tests were added.

## Release Plan:
Not on production.

#### Release Checklist Items Skipped?
N/A
