### PR TITLE
trasform username parameter to lowercase

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -36,6 +36,7 @@ const validateQueryParams = (req) => {
 
   return Promise.resolve({
     ...req.query,
+    username: username.toLowerCase(),
     count: countNumber
   });
 };

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -284,6 +284,9 @@ describe("Timelines", () => {
           tweets: sample2Tweets
         });
 
+        assert(twitter.getUserTimeline.called);
+        assert.equal(twitter.getUserTimeline.lastCall.args[1], "risevision");
+
         assert(!res.status.called);
         assert(!res.send.called);
 
@@ -314,8 +317,31 @@ describe("Timelines", () => {
 
         assert(!res.status.called);
         assert(!res.send.called);
+
+        assert(twitter.getUserTimeline.called);
+        assert.equal(twitter.getUserTimeline.lastCall.args[1], "risevision");
       });
     });
+
+    it("should transform username to lowercase", () => {
+      req.query.username = "UPPERCASE";
+      simple.mock(twitter, "getUserTimeline").resolveWith(sample2Tweets);
+
+      return timelines.handleGetTweetsRequest(req, res)
+      .then(() => {
+        assert(res.json.called);
+
+        assert(twitter.getUserTimeline.called);
+        assert.equal(twitter.getUserTimeline.lastCall.args[1], "uppercase");
+
+        assert(!res.status.called);
+        assert(!res.send.called);
+
+        assert.equal(cache.saveStatus.calls[0].args[0], "uppercase");
+        assert.equal(cache.saveStatus.calls[1].args[0], "uppercase");
+      });
+    });
+
   });
 
   describe("handleGetTweetsRequest / Limit output", () => {


### PR DESCRIPTION
## Description
Always transform username to lowercase

## Motivation and Context
Twitter screen names are case insensitive, so RiseVision, risevision, RISEVISION refer to the same timeline. In order to avoid creating different cache entries for each one of these keys, this code transforms all usernames to lowercase.

## How Has This Been Tested?
Tested here: http://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RISEVISION&count=10

which returns the same as: http://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RiseVision&count=10

Unit tests added

## Release Plan:
Not in production

#### Release Checklist Items Skipped?
N/A
