### PR TITLE
Timeline Data Formatting

### DIFF
--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -1,41 +1,44 @@
+/* eslint-disable no-warning-comments */
 
 const getStatisticsFields = (tweet) => {
   return {
-    retweetCount: !("retweet_count" in tweet) ? null : tweet.retweet_count,
-    likeCount: !("favorite_count" in tweet) ? null : tweet.favorite_count
+    retweetCount: "retweet_count" in tweet ? tweet.retweet_count : null,
+    likeCount: "favorite_count" in tweet ? tweet.favorite_count : null
   };
 };
 
 const getUserFields = (tweet) => {
-  if (!("user" in tweet)) { return {}}
+  if (!("user" in tweet)) {return {}}
 
   return {
-    description: !("description" in tweet.user) ? null : tweet.user.description,
-    statuses: !("statuses_count" in tweet.user) ? null : tweet.user.statuses_count,
-    followers: !("followers_count" in tweet.user) ? null : tweet.user.followers_count
+    description: "description" in tweet.user ? tweet.user.description : null,
+    statuses: "statuses_count" in tweet.user ? tweet.user.statuses_count : null,
+    followers: "followers_count" in tweet.user ? tweet.user.followers_count : null
   };
 };
 
 const getRootFields = (tweet) => {
-  let userFields = {};
+  const userFields = {};
 
-  if (!("user" in tweet)) {
-    userFields.name = userFields.screenName = userFields.profilePicture = null;
+  if ("user" in tweet) {
+    userFields.name = "name" in tweet.user ? tweet.user.name : null;
+    userFields.screenName = "screen_name" in tweet.user ? tweet.user.screen_name : null;
+    userFields.profilePicture = "profile_image_url_https" in tweet.user ? tweet.user.profile_image_url_https : null;
   } else {
-    userFields.name = !("name" in tweet.user) ? null : tweet.user.name;
-    userFields.screenName = !("screen_name" in tweet.user) ? null : tweet.user.screen_name;
-    userFields.profilePicture = !("profile_image_url_https" in tweet.user) ? null : tweet.user.profile_image_url_https;
+    userFields.name = null;
+    userFields.screenName = null;
+    userFields.profilePicture = null;
   }
 
   // TODO: text, image, and quoted fields
 
   return Object.assign({}, userFields, {
-    createdAt: !("created_at" in tweet) ? null : tweet.created_at
+    createdAt: "created_at" in tweet ? tweet.created_at : null
   })
 };
 
 const getTweetFormatted = (tweet) => {
-  let subFields = {};
+  const subFields = {};
 
   subFields.user = getUserFields(tweet);
   subFields.statistics = getStatisticsFields(tweet);
@@ -48,7 +51,7 @@ const getTimelineFormatted = (timeline) => {
     return [];
   }
 
-  return timeline.map(tweet => getTweetFormatted((JSON.parse(JSON.stringify(tweet)))));
+  return timeline.map(tweet => getTweetFormatted(JSON.parse(JSON.stringify(tweet))));
 };
 
 module.exports = {

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -1,0 +1,56 @@
+
+const getStatisticsFields = (tweet) => {
+  return {
+    retweetCount: !("retweet_count" in tweet) ? null : tweet.retweet_count,
+    likeCount: !("favorite_count" in tweet) ? null : tweet.favorite_count
+  };
+};
+
+const getUserFields = (tweet) => {
+  if (!("user" in tweet)) { return {}}
+
+  return {
+    description: !("description" in tweet.user) ? null : tweet.user.description,
+    statuses: !("statuses_count" in tweet.user) ? null : tweet.user.statuses_count,
+    followers: !("followers_count" in tweet.user) ? null : tweet.user.followers_count
+  };
+};
+
+const getRootFields = (tweet) => {
+  let userFields = {};
+
+  if (!("user" in tweet)) {
+    userFields.name = userFields.screenName = userFields.profilePicture = null;
+  } else {
+    userFields.name = !("name" in tweet.user) ? null : tweet.user.name;
+    userFields.screenName = !("screen_name" in tweet.user) ? null : tweet.user.screen_name;
+    userFields.profilePicture = !("profile_image_url_https" in tweet.user) ? null : tweet.user.profile_image_url_https;
+  }
+
+  // TODO: text, image, and quoted fields
+
+  return Object.assign({}, userFields, {
+    createdAt: !("created_at" in tweet) ? null : tweet.created_at
+  })
+};
+
+const getTweetFormatted = (tweet) => {
+  let subFields = {};
+
+  subFields.user = getUserFields(tweet);
+  subFields.statistics = getStatisticsFields(tweet);
+
+  return Object.assign({}, getRootFields(tweet), subFields);
+};
+
+const getTimelineFormatted = (timeline) => {
+  if (!timeline || !timeline.length || timeline.length <= 0) {
+    return [];
+  }
+
+  return timeline.map(tweet => getTweetFormatted((JSON.parse(JSON.stringify(tweet)))));
+};
+
+module.exports = {
+  getTimelineFormatted
+};

--- a/test/unit/samples/tweets-timeline.js
+++ b/test/unit/samples/tweets-timeline.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-magic-numbers */
+
 module.exports = {
   data: [
     {
@@ -84,7 +86,7 @@ module.exports = {
         "favourites_count": 1290,
         "statuses_count": 371523,
         "profile_image_url": "http://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png",
-        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png"
       },
       "is_quote_status": false,
       "retweet_count": 2,

--- a/test/unit/samples/tweets-timeline.js
+++ b/test/unit/samples/tweets-timeline.js
@@ -1,0 +1,94 @@
+module.exports = {
+  data: [
+    {
+      "created_at": "Tue Feb 25 20:23:02 +0000 2020",
+      "id": 1,
+      "id_str": "1",
+      "text": "Example with image(s)",
+      "truncated": false,
+      "extended_entities": {
+        "media": [
+          {
+            "id": 123,
+            "id_str": "123",
+            "indices": [
+              104,
+              127
+            ],
+            "media_url": "http://pbs.twimg.com/media/ERpd155WAAIbGuw.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/ERpd155WAAIbGuw.jpg",
+            "url": "https://t.co/CSVX15F6HF",
+            "display_url": "pic.twitter.com/CSVX15F6HF",
+            "expanded_url": "https://twitter.com/mashable/status/1232400631207473152/photo/1",
+            "type": "photo",
+            "sizes": {
+              "large": {
+                "w": 947,
+                "h": 531,
+                "resize": "fit"
+              },
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "small": {
+                "w": 680,
+                "h": 381,
+                "resize": "fit"
+              },
+              "medium": {
+                "w": 947,
+                "h": 531,
+                "resize": "fit"
+              }
+            }
+          }
+        ]
+      },
+      "user": {
+        "id": 987,
+        "id_str": "987",
+        "name": "Twitter Service Test",
+        "screen_name": "ts_test",
+        "description": "Twitter Service test coverage",
+        "followers_count": 9803330,
+        "friends_count": 2785,
+        "listed_count": 126334,
+        "created_at": "Mon Mar 12 01:28:01 +0000 2007",
+        "favourites_count": 1290,
+        "statuses_count": 371523,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png"
+      },
+      "is_quote_status": false,
+      "retweet_count": 2,
+      "favorite_count": 10
+    },
+    {
+      "created_at": "Tue Feb 25 20:19:06 +0000 2020",
+      "id": 2,
+      "id_str": "2",
+      "text": "Example without images",
+      "truncated": false,
+      "user": {
+        "id": 987,
+        "id_str": "987",
+        "name": "Twitter Service Test",
+        "screen_name": "ts_test",
+        "description": "Twitter Service test coverage",
+        "followers_count": 9803330,
+        "friends_count": 2785,
+        "listed_count": 126334,
+        "created_at": "Mon Mar 12 01:28:01 +0000 2007",
+        "favourites_count": 1290,
+        "statuses_count": 371523,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe_normal.png",
+      },
+      "is_quote_status": false,
+      "retweet_count": 2,
+      "favorite_count": 5
+    }
+  ]
+};

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -1,0 +1,28 @@
+const assert = require("assert");
+const simple = require("simple-mock");
+
+const timelineFormatter = require("../../src/timelines/data_formatter");
+
+const sampleTweets = require("./samples/tweets-timeline").data;
+
+describe("Timelines Data Formatting", () => {
+
+  beforeEach(() => {
+
+  });
+
+  afterEach(() => {
+    simple.restore();
+  });
+
+  describe("getTimelineFormatted / statistics", () => {
+    it("should populate correct values", () => {
+      const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
+
+      assert.deepEqual(formatted[0].statistics, {
+        retweetCount: sampleTweets[0].retweet_count,
+        likeCount: sampleTweets[0].favorite_count
+      });
+    });
+  });
+});

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -16,13 +16,92 @@ describe("Timelines Data Formatting", () => {
   });
 
   describe("getTimelineFormatted / statistics", () => {
-    it("should populate correct values", () => {
+    it("should populate statistics values", () => {
       const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
 
       assert.deepEqual(formatted[0].statistics, {
         retweetCount: sampleTweets[0].retweet_count,
         likeCount: sampleTweets[0].favorite_count
       });
+    });
+
+    it("should nullify statistics values when timeline missing required fields", () => {
+      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0], "retweet_count");
+      Reflect.deleteProperty(modifiedSampleTweets[0], "favorite_count");
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].statistics, {
+        retweetCount: null,
+        likeCount: null
+      });
+    });
+  });
+
+  describe("getTimelineFormatted / user", () => {
+    it("should populate user values", () => {
+      const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
+
+      assert.deepEqual(formatted[0].user, {
+        description: sampleTweets[0].user.description,
+        statuses: sampleTweets[0].user.statuses_count,
+        followers: sampleTweets[0].user.followers_count
+      });
+    });
+
+    it("should nullify user values when timeline missing required user fields", () => {
+      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0].user, "description");
+      Reflect.deleteProperty(modifiedSampleTweets[0].user, "statuses_count");
+      Reflect.deleteProperty(modifiedSampleTweets[0].user, "followers_count");
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].user, {
+        description: null,
+        statuses: null,
+        followers: null
+      });
+    });
+
+    it("should populate empty object for user when required user field missing", () => {
+      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0], "user");
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].user, {});
+    });
+  });
+
+  describe("getTimelineFormatted / root", () => {
+    it("should populate root values", () => {
+      const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
+
+      assert.equal(formatted[0].name, sampleTweets[0].user.name);
+      assert.equal(formatted[0].screenName, sampleTweets[0].user.screen_name);
+      assert.equal(formatted[0].profilePicture, sampleTweets[0].user.profile_image_url_https);
+      assert.equal(formatted[0].createdAt, sampleTweets[0].created_at);
+    });
+
+    it("should nullify root values when timeline missing required fields", () => {
+      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0].user, "name");
+      Reflect.deleteProperty(modifiedSampleTweets[0].user, "screen_name");
+      Reflect.deleteProperty(modifiedSampleTweets[0].user, "profile_image_url_https");
+      Reflect.deleteProperty(modifiedSampleTweets[0], "created_at");
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[0].name === null);
+      assert(formatted[0].screenName === null);
+      assert(formatted[0].profilePicture === null);
+      assert(formatted[0].createdAt === null);
     });
   });
 });


### PR DESCRIPTION
## Description
Created timeline data formatter 

Formatting as follows:

```
{
  name: ...,
  screenName: ...,
  profilePicture: ...,
  createdAt: ...,
  user: {
    description: ...
    statuses: ...
    followers: ...
  },
  statistics: {
    retweetCount: ...,
    likeCount: ...
  }
}
```
Ensuring to always account for fields missing since Twitter API is constantly evolving.

The following data will be included in follow up PRs: `quote`, `images`, `text`

Returning this formatted data from a `get-tweets` request also coming in later PR

## Motivation and Context
Twitter Service development

## How Has This Been Tested?
Unit test coverage. Full testing will occur in follow up PR when data is returned from `get-tweets` request

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
