### PR TITLE
Formatting 'text' value from user_timeline data

### DIFF
--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -17,6 +17,18 @@ const getUserFields = (tweet) => {
   };
 };
 
+const getTextField = (tweet) => {
+  if ("full_text" in tweet) {
+    return tweet.full_text;
+  }
+
+  if ("text" in tweet) {
+    return tweet.text;
+  }
+
+  return null;
+};
+
 const getRootFields = (tweet) => {
   const userFields = {};
 
@@ -30,10 +42,11 @@ const getRootFields = (tweet) => {
     userFields.profilePicture = null;
   }
 
-  // TODO: text, image, and quoted fields
+  // TODO: image, and quoted fields
 
   return Object.assign({}, userFields, {
-    createdAt: "created_at" in tweet ? tweet.created_at : null
+    createdAt: "created_at" in tweet ? tweet.created_at : null,
+    text: getTextField(tweet)
   })
 };
 

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -27,8 +27,9 @@ const verifyCredentials = credentials => {
 const getUserTimeline = (credentials, username) => {
   const args = {
     screen_name: username,
-    count: numberOfCachedTweets
-  }
+    count: numberOfCachedTweets,
+    tweet_mode: 'extended'
+  };
 
   return invokeEndpoint(credentials, 'statuses/user_timeline', args);
 };

--- a/test/unit/samples/tweets-timeline.js
+++ b/test/unit/samples/tweets-timeline.js
@@ -6,7 +6,7 @@ module.exports = {
       "created_at": "Tue Feb 25 20:23:02 +0000 2020",
       "id": 1,
       "id_str": "1",
-      "text": "Example with image(s)",
+      "full_text": "Example with image(s)",
       "truncated": false,
       "extended_entities": {
         "media": [
@@ -71,7 +71,7 @@ module.exports = {
       "created_at": "Tue Feb 25 20:19:06 +0000 2020",
       "id": 2,
       "id_str": "2",
-      "text": "Example without images",
+      "full_text": "Example without images",
       "truncated": false,
       "user": {
         "id": 987,

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-statements */
+
 const assert = require("assert");
 const simple = require("simple-mock");
 
@@ -86,6 +88,7 @@ describe("Timelines Data Formatting", () => {
       assert.equal(formatted[0].screenName, sampleTweets[0].user.screen_name);
       assert.equal(formatted[0].profilePicture, sampleTweets[0].user.profile_image_url_https);
       assert.equal(formatted[0].createdAt, sampleTweets[0].created_at);
+      assert.equal(formatted[0].text, sampleTweets[0].full_text);
     });
 
     it("should nullify root values when timeline missing required fields", () => {
@@ -95,6 +98,7 @@ describe("Timelines Data Formatting", () => {
       Reflect.deleteProperty(modifiedSampleTweets[0].user, "screen_name");
       Reflect.deleteProperty(modifiedSampleTweets[0].user, "profile_image_url_https");
       Reflect.deleteProperty(modifiedSampleTweets[0], "created_at");
+      Reflect.deleteProperty(modifiedSampleTweets[0], "full_text");
 
       const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
 
@@ -102,6 +106,20 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].screenName === null);
       assert(formatted[0].profilePicture === null);
       assert(formatted[0].createdAt === null);
+      assert(formatted[0].text === null);
+    });
+
+    it("should fallback on 'text' if 'full_text' not present", () => {
+      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets)),
+        text = "Testing fallback on text";
+
+      Reflect.deleteProperty(modifiedSampleTweets[0], "full_text");
+
+      modifiedSampleTweets[0].text = text;
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[0].text === text);
     });
   });
 });


### PR DESCRIPTION
## Description
Ensuring to include `tweet_mode=extended` in the query params of the _user-timeline_ request in order to contain all information from Tweets that contain more than 140 characters. The response provides `full_text` as a replacement of `text`. Full overview is [here](https://developer.twitter.com/en/docs/tweets/tweet-updates)

Adding `text` value as part of the timeline data formatter. It is the value of `full_text` in the _user-timeline_ response, and if this is not present, falling back on `text` property in the response instead, otherwise it will be `null`. 

Included in the root of the tweet data, for example:

```
{
  name: ...,
  screenName: ...,
  text: ...,
  ...
}
```

The following data will be included in follow up PRs: `quote`, `images`

Returning this formatted data from a `get-tweets` request also coming in later PR

## Motivation and Context
Twitter Service development

## How Has This Been Tested?
Unit test coverage. Full testing will occur in follow up PR when data is returned from `get-tweets` request

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
