### PR TITLE
Format images for get-tweets response

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,5 +3,7 @@ module.exports = {
   FORBIDDEN_ERROR: 403,
   CONFLICT_ERROR: 409,
   CONFLICT_ERROR_MESSAGE: "Another request is already loading user timeline. Please retry in a few seconds.",
-  SERVER_ERROR: 500
+  SERVER_ERROR: 500,
+  MEDIA_TYPE_IMAGE: "photo",
+  MEDIA_TYPE_ANIMATED_GIF: "animated_gif"
 };

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -1,5 +1,38 @@
 /* eslint-disable no-warning-comments */
 
+const constants = require('../constants');
+const allowedMediaTypes = [constants.MEDIA_TYPE_IMAGE, constants.MEDIA_TYPE_ANIMATED_GIF];
+
+const isExpectedMediaFormat = (tweet) => {
+  if (!("extended_entities" in tweet)) {return false}
+
+  if (!("media" in tweet.extended_entities)) {return false}
+
+  if (!Array.isArray(tweet.extended_entities.media) || tweet.extended_entities.media.length === 0) {return false;}
+
+  if (!("type" in tweet.extended_entities.media[0])) {return false}
+
+  return allowedMediaTypes.includes(tweet.extended_entities.media[0].type);
+};
+
+const getFormattedImageURL = (imageItem) => {
+  if (!("media_url_https" in imageItem)) {return ""}
+
+  const baseUrl = imageItem.media_url_https.substring(0, imageItem.media_url_https.lastIndexOf(".")),
+    extension = imageItem.media_url_https.slice(imageItem.media_url_https.lastIndexOf(".") + 1),
+    name = "large";
+
+  return `${baseUrl}?format=${extension}&name=${name}`
+};
+
+const getImagesField = (tweet) => {
+  if (!isExpectedMediaFormat(tweet)) {return []}
+
+  const images = tweet.extended_entities.media.map(imageItem => getFormattedImageURL(JSON.parse(JSON.stringify(imageItem))));
+
+  return images.filter(url => url !== "");
+};
+
 const getStatisticsFields = (tweet) => {
   return {
     retweetCount: "retweet_count" in tweet ? tweet.retweet_count : null,
@@ -46,7 +79,8 @@ const getRootFields = (tweet) => {
 
   return Object.assign({}, userFields, {
     createdAt: "created_at" in tweet ? tweet.created_at : null,
-    text: getTextField(tweet)
+    text: getTextField(tweet),
+    images: getImagesField(tweet)
   })
 };
 

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-warning-comments */
 
 const constants = require('../constants');
+const utils = require('../utils');
 const allowedMediaTypes = [constants.MEDIA_TYPE_IMAGE, constants.MEDIA_TYPE_ANIMATED_GIF];
 
 const isExpectedMediaFormat = (tweet) => {
@@ -28,7 +29,7 @@ const getFormattedImageURL = (imageItem) => {
 const getImagesField = (tweet) => {
   if (!isExpectedMediaFormat(tweet)) {return []}
 
-  const images = tweet.extended_entities.media.map(imageItem => getFormattedImageURL(JSON.parse(JSON.stringify(imageItem))));
+  const images = tweet.extended_entities.media.map(imageItem => getFormattedImageURL(utils.deepClone(imageItem)));
 
   return images.filter(url => url !== "");
 };
@@ -98,7 +99,7 @@ const getTimelineFormatted = (timeline) => {
     return [];
   }
 
-  return timeline.map(tweet => getTweetFormatted(JSON.parse(JSON.stringify(tweet))));
+  return timeline.map(tweet => getTweetFormatted(utils.deepClone(tweet)));
 };
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+const deepClone = (obj) => {
+  return JSON.parse(JSON.stringify(obj));
+};
+
+module.exports = {
+  deepClone
+};

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -2,6 +2,7 @@
 
 const assert = require("assert");
 const simple = require("simple-mock");
+const utils = require("../../src/utils");
 
 const timelineFormatter = require("../../src/timelines/data_formatter");
 
@@ -28,7 +29,7 @@ describe("Timelines Data Formatting", () => {
     });
 
     it("should nullify statistics values when timeline missing required fields", () => {
-      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      const modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0], "retweet_count");
       Reflect.deleteProperty(modifiedSampleTweets[0], "favorite_count");
@@ -54,7 +55,7 @@ describe("Timelines Data Formatting", () => {
     });
 
     it("should nullify user values when timeline missing required user fields", () => {
-      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      const modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0].user, "description");
       Reflect.deleteProperty(modifiedSampleTweets[0].user, "statuses_count");
@@ -70,7 +71,7 @@ describe("Timelines Data Formatting", () => {
     });
 
     it("should populate empty object for user when required user field missing", () => {
-      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      const modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0], "user");
 
@@ -93,7 +94,7 @@ describe("Timelines Data Formatting", () => {
     });
 
     it("should nullify root values when timeline missing required fields", () => {
-      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      const modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0].user, "name");
       Reflect.deleteProperty(modifiedSampleTweets[0].user, "screen_name");
@@ -111,7 +112,7 @@ describe("Timelines Data Formatting", () => {
     });
 
     it("should fallback on 'text' if 'full_text' not present", () => {
-      const modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets)),
+      const modifiedSampleTweets = utils.deepClone(sampleTweets),
         text = "Testing fallback on text";
 
       Reflect.deleteProperty(modifiedSampleTweets[0], "full_text");
@@ -125,7 +126,7 @@ describe("Timelines Data Formatting", () => {
 
     it("should return an empty array for 'images' if required fields missing", () => {
       // test for missing "extended_entities"
-      let modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      let modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0], "extended_entities");
 
@@ -134,7 +135,7 @@ describe("Timelines Data Formatting", () => {
       assert.deepEqual(formatted[0].images, []);
 
       // test for missing "media"
-      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities, "media");
 
@@ -143,7 +144,7 @@ describe("Timelines Data Formatting", () => {
       assert.deepEqual(formatted[0].images, []);
 
       // test for invalid "media"
-      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities, "media");
       modifiedSampleTweets[0].extended_entities.media = "test";
@@ -153,7 +154,7 @@ describe("Timelines Data Formatting", () => {
       assert.deepEqual(formatted[0].images, []);
 
       // test for missing "type"
-      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities.media[0], "type");
 
@@ -162,7 +163,7 @@ describe("Timelines Data Formatting", () => {
       assert.deepEqual(formatted[0].images, []);
 
       // test for invalid "type"
-      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
       modifiedSampleTweets[0].extended_entities.media[0].type = "test";
 
       formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
@@ -170,7 +171,7 @@ describe("Timelines Data Formatting", () => {
       assert.deepEqual(formatted[0].images, []);
 
       // test for missing "media_url_https"
-      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
 
       Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities.media[0], "media_url_https");
 

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -89,6 +89,7 @@ describe("Timelines Data Formatting", () => {
       assert.equal(formatted[0].profilePicture, sampleTweets[0].user.profile_image_url_https);
       assert.equal(formatted[0].createdAt, sampleTweets[0].created_at);
       assert.equal(formatted[0].text, sampleTweets[0].full_text);
+      assert.deepEqual(formatted[0].images, ["https://pbs.twimg.com/media/ERpd155WAAIbGuw?format=jpg&name=large"]);
     });
 
     it("should nullify root values when timeline missing required fields", () => {
@@ -120,6 +121,63 @@ describe("Timelines Data Formatting", () => {
       const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
 
       assert(formatted[0].text === text);
+    });
+
+    it("should return an empty array for 'images' if required fields missing", () => {
+      // test for missing "extended_entities"
+      let modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0], "extended_entities");
+
+      let formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].images, []);
+
+      // test for missing "media"
+      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities, "media");
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].images, []);
+
+      // test for invalid "media"
+      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities, "media");
+      modifiedSampleTweets[0].extended_entities.media = "test";
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].images, []);
+
+      // test for missing "type"
+      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities.media[0], "type");
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].images, []);
+
+      // test for invalid "type"
+      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+      modifiedSampleTweets[0].extended_entities.media[0].type = "test";
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].images, []);
+
+      // test for missing "media_url_https"
+      modifiedSampleTweets = JSON.parse(JSON.stringify(sampleTweets));
+
+      Reflect.deleteProperty(modifiedSampleTweets[0].extended_entities.media[0], "media_url_https");
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert.deepEqual(formatted[0].images, []);
+
     });
   });
 });


### PR DESCRIPTION
## Description
Adding `images` value as part of the timeline data formatter. 

Value is an Array of constructed image URLs as per [design](https://docs.google.com/document/d/14wmYT9KGhbkzvd4kYrtO-TiooVtSEv0NrhD5iNp-bew/edit#bookmark=id.uktqgq6bbl0n) 

Acceptable types of media are `photo` and `animated_gif`

Accounting for any missing required fields in _user-timeline_ response, value will be empty Array

Included in the root of the tweet data, for example:

```
{
  name: ...,
  screenName: ...,
  images: [..., ...],
  ...
}
```

The following data will be included in follow up PRs: `quote`

Returning this formatted data from a `get-tweets` request also coming in later PR

## Motivation and Context
Twitter Service development

## How Has This Been Tested?
Unit test coverage. Full testing will occur in follow up PR when data is returned from `get-tweets` request

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
