### PR TITLE
Format quoted value for get-tweets response

### DIFF
--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -34,6 +34,16 @@ const getImagesField = (tweet) => {
   return images.filter(url => url !== "");
 };
 
+const getQuotedField = (tweet) => {
+  if (!("is_quote_status" in tweet)) {return null;}
+
+  if (!tweet.is_quote_status) {return null;}
+
+  if (!("quoted_status" in tweet)) {return null;}
+
+  return getTweetFormatted(tweet.quoted_status, false);
+};
+
 const getStatisticsFields = (tweet) => {
   return {
     retweetCount: "retweet_count" in tweet ? tweet.retweet_count : null,
@@ -76,8 +86,6 @@ const getRootFields = (tweet) => {
     userFields.profilePicture = null;
   }
 
-  // TODO: image, and quoted fields
-
   return Object.assign({}, userFields, {
     createdAt: "created_at" in tweet ? tweet.created_at : null,
     text: getTextField(tweet),
@@ -85,11 +93,12 @@ const getRootFields = (tweet) => {
   })
 };
 
-const getTweetFormatted = (tweet) => {
+const getTweetFormatted = (tweet, includeQuoted = true) => {
   const subFields = {};
 
   subFields.user = getUserFields(tweet);
   subFields.statistics = getStatisticsFields(tweet);
+  subFields.quoted = includeQuoted ? getQuotedField(tweet) : null;
 
   return Object.assign({}, getRootFields(tweet), subFields);
 };

--- a/test/unit/samples/tweets-timeline.js
+++ b/test/unit/samples/tweets-timeline.js
@@ -91,6 +91,137 @@ module.exports = {
       "is_quote_status": false,
       "retweet_count": 2,
       "favorite_count": 5
+    },
+    {
+      "created_at": "Thu Mar 05 09:44:54 +0000 2020",
+      "id": 3,
+      "id_str": "3",
+      "full_text": "Example quoted tweet️ https://t.co/LaBVFfKQUE",
+      "truncated": false,
+      "user": {
+        "id": 456,
+        "id_str": "456",
+        "name": "Sarah Silverman",
+        "screen_name": "SarahKSilverman",
+        "description": "we're on a planet in outer space",
+        "followers_count": 12609760,
+        "friends_count": 1572,
+        "listed_count": 54516,
+        "created_at": "Sat Apr 11 01:28:47 +0000 2009",
+        "favourites_count": 32369,
+        "statuses_count": 15965,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/869453546298646528/BAgmD_Vn_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/869453546298646528/BAgmD_Vn_normal.jpg"
+      },
+      "is_quote_status": true,
+      "quoted_status_id": 1235453238100414500,
+      "quoted_status_id_str": "1235453238100414464",
+      "quoted_status_permalink": {
+        "url": "https://t.co/LaBVFfKQUE",
+        "expanded": "https://twitter.com/nowthisnews/status/1235453238100414464",
+        "display": "twitter.com/nowthisnews/st…"
+      },
+      "quoted_status": {
+        "created_at": "Thu Mar 05 06:33:00 +0000 2020",
+        "id": 1235453238100414500,
+        "id_str": "1235453238100414464",
+        "full_text": "This ER doctor called the lack of accurate coronavirus testing in the U.S. a ‘national scandal,’ warning that cases could rise to the thousands by next week https://t.co/LA5tgQEtU8",
+        "truncated": false,
+        "extended_entities": {
+          "media": [
+            {
+              "id": 1234946742543638500,
+              "id_str": "1234946742543638530",
+              "indices": [
+                157,
+                180
+              ],
+              "media_url": "http://pbs.twimg.com/media/ESNqIDBXUAUv2r1.jpg",
+              "media_url_https": "https://pbs.twimg.com/media/ESNqIDBXUAUv2r1.jpg",
+              "url": "https://t.co/LA5tgQEtU8",
+              "display_url": "pic.twitter.com/LA5tgQEtU8",
+              "expanded_url": "https://twitter.com/nowthisnews/status/1235453238100414464/video/1",
+              "type": "video",
+              "sizes": {
+                "small": {
+                  "w": 480,
+                  "h": 480,
+                  "resize": "fit"
+                },
+                "thumb": {
+                  "w": 150,
+                  "h": 150,
+                  "resize": "crop"
+                },
+                "medium": {
+                  "w": 480,
+                  "h": 480,
+                  "resize": "fit"
+                },
+                "large": {
+                  "w": 480,
+                  "h": 480,
+                  "resize": "fit"
+                }
+              },
+              "video_info": {
+                "aspect_ratio": [
+                  1,
+                  1
+                ],
+                "duration_millis": 196931,
+                "variants": [
+                  {
+                    "bitrate": 1280000,
+                    "content_type": "video/mp4",
+                    "url": "https://video.twimg.com/amplify_video/1234946742543638530/vid/720x720/SdjcujD6rxdptFZR.mp4?tag=13"
+                  },
+                  {
+                    "bitrate": 432000,
+                    "content_type": "video/mp4",
+                    "url": "https://video.twimg.com/amplify_video/1234946742543638530/vid/320x320/nZaFVSnXB01SyILV.mp4?tag=13"
+                  },
+                  {
+                    "content_type": "application/x-mpegURL",
+                    "url": "https://video.twimg.com/amplify_video/1234946742543638530/pl/RFbKt-U4MJZBT-KV.m3u8?tag=13"
+                  },
+                  {
+                    "bitrate": 832000,
+                    "content_type": "video/mp4",
+                    "url": "https://video.twimg.com/amplify_video/1234946742543638530/vid/480x480/QcLzY7owZZ_onRh-.mp4?tag=13"
+                  }
+                ]
+              },
+              "additional_media_info": {
+                "title": "Doctor Calls Lack of Accurate Coronavirus Tests a 'National Scandal' ",
+                "description": "This ER doctor called the lack of accurate coronavirus testing in the U.S. a ‘national scandal,’ warning that cases could rise to the thousands by next week",
+                "embeddable": true,
+                "monetizable": false
+              }
+            }
+          ]
+        },
+        "user": {
+          "id": 701725963,
+          "id_str": "701725963",
+          "name": "NowThis",
+          "screen_name": "nowthisnews",
+          "description": "Stories that move. Send us tips: contact@nowthismedia.com. Subscribe to our daily newsletter: https://t.co/2sCY2rymF7",
+          "followers_count": 2519760,
+          "friends_count": 12077,
+          "listed_count": 10411,
+          "created_at": "Tue Jul 17 20:31:08 +0000 2012",
+          "favourites_count": 13195,
+          "statuses_count": 147859,
+          "profile_image_url": "http://pbs.twimg.com/profile_images/1197533022263877635/JxM1Ba0d_normal.jpg",
+          "profile_image_url_https": "https://pbs.twimg.com/profile_images/1197533022263877635/JxM1Ba0d_normal.jpg"
+        },
+        "is_quote_status": false,
+        "retweet_count": 1137,
+        "favorite_count": 2243
+      },
+      "retweet_count": 282,
+      "favorite_count": 1060
     }
   ]
 };

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-statements */
+/* eslint-disable max-statements, no-magic-numbers */
 
 const assert = require("assert");
 const simple = require("simple-mock");
@@ -180,5 +180,61 @@ describe("Timelines Data Formatting", () => {
       assert.deepEqual(formatted[0].images, []);
 
     });
+  });
+
+  describe("getTimelineFormatted / quoted", () => {
+    it("should populate quoted object", () => {
+      const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
+
+      assert.deepEqual(formatted[2].quoted.user, {
+        description: sampleTweets[2].quoted_status.user.description,
+        statuses: sampleTweets[2].quoted_status.user.statuses_count,
+        followers: sampleTweets[2].quoted_status.user.followers_count
+      });
+
+      assert.deepEqual(formatted[2].quoted.statistics, {
+        retweetCount: sampleTweets[2].quoted_status.retweet_count,
+        likeCount: sampleTweets[2].quoted_status.favorite_count
+      });
+
+      assert.equal(formatted[2].quoted.name, sampleTweets[2].quoted_status.user.name);
+      assert.equal(formatted[2].quoted.screenName, sampleTweets[2].quoted_status.user.screen_name);
+      assert.equal(formatted[2].quoted.profilePicture, sampleTweets[2].quoted_status.user.profile_image_url_https);
+      assert.equal(formatted[2].quoted.createdAt, sampleTweets[2].quoted_status.created_at);
+      assert.equal(formatted[2].quoted.text, sampleTweets[2].quoted_status.full_text);
+      assert.deepEqual(formatted[2].images, []);
+
+      assert(formatted[2].quoted.quoted === null);
+    });
+
+    it("should nullify 'quoted' if required fields missing", () => {
+      // test for missing "is_quote_status"
+      let modifiedSampleTweets = utils.deepClone(sampleTweets);
+
+      Reflect.deleteProperty(modifiedSampleTweets[2], "is_quote_status");
+
+      let formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[2].quoted === null);
+
+      // test for quote_status equal to false
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
+
+      modifiedSampleTweets[2].is_quote_status = false;
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[2].quoted === null);
+
+      // test for missing "quoted_status"
+      modifiedSampleTweets = utils.deepClone(sampleTweets);
+
+      Reflect.deleteProperty(modifiedSampleTweets[2], "quoted_status");
+
+      formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[2].quoted === null);
+    });
+
   });
 });


### PR DESCRIPTION
## Description
Adding `quoted` value as part of the timeline data formatter. 

Value is an Object formatted the same as a regular tweet object we respond with, based on the data from the `quoted_status` value in the _user-timeline_ response. As per [design](https://docs.google.com/document/d/14wmYT9KGhbkzvd4kYrtO-TiooVtSEv0NrhD5iNp-bew/edit#bookmark=id.gz4d6b4ahj31) 

Accounting for any missing required fields in _user-timeline_ response, value will be `null`

Only providing top level quoted value, no further nested quoted tweets. 

Structured in the response as per example:

```
{
  name: ...,
  screenName: ...,
  quoted: {
    name: ...,
    screenName: ...,
    ...
  },
  ...
}
```

Returning this fully formatted data from a `get-tweets` request coming in follow up PR

## Motivation and Context
Twitter Service development

## How Has This Been Tested?
Unit test coverage. Full testing will occur in follow up PR when data is returned from `get-tweets` request

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
