### PR TITLE
Respond with formatted data for get-tweets endpoint

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -5,6 +5,7 @@ const constants = require('../constants');
 const cache = require('../redis-cache/api');
 const oauthTokenProvider = require("../redis-otp/api");
 const twitter = require('../twitter');
+const formatter = require('./data_formatter');
 
 const {
   BAD_REQUEST_ERROR, CONFLICT_ERROR, CONFLICT_ERROR_MESSAGE, FORBIDDEN_ERROR,
@@ -92,8 +93,10 @@ const requestRemoteUserTimeline = (query, res, credentials) => {
   .then(() => {
     return twitter.getUserTimeline(credentials, query.username)
     .then(timeline => {
+      const formattedTimeline = formatter.getTimelineFormatted(timeline);
+
       return saveLoadingFlag(query, false)
-      .then(() => returnTimeline(query, res, timeline));
+      .then(() => returnTimeline(query, res, formattedTimeline));
     })
     .catch(error => {
       return saveLoadingFlag(query, false)

--- a/test/unit/samples/tweets-2.js
+++ b/test/unit/samples/tweets-2.js
@@ -1,6 +1,0 @@
-module.exports = {
-  data: [
-    {"id": "1"},
-    {"id": "2"}
-  ]
-};

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -8,10 +8,14 @@ const oauthTokenProvider = require("../../src/redis-otp/api");
 const config = require("../../src/config");
 const constants = require("../../src/constants");
 const timelines = require("../../src/timelines");
+const formatter = require("../../src/timelines/data_formatter");
 const twitter = require("../../src/twitter");
 
 const sample2Tweets = require("./samples/tweets-2").data;
 const sample30Tweets = require("./samples/tweets-30").data;
+const sampleTweets = require("./samples/tweets-timeline").data;
+
+const sampleTweetsFormatted = formatter.getTimelineFormatted(sampleTweets);
 
 const {
   BAD_REQUEST_ERROR, CONFLICT_ERROR, CONFLICT_ERROR_MESSAGE, FORBIDDEN_ERROR,
@@ -160,7 +164,7 @@ describe("Timelines", () => {
     });
 
     it("should return tweets if loading is turned on but it has expired", () => {
-      simple.mock(twitter, "getUserTimeline").resolveWith(sample2Tweets);
+      simple.mock(twitter, "getUserTimeline").resolveWith(sampleTweets);
       simple.mock(cache, "getStatusFor").resolveWith({
         loading: true,
         loadingStarted: new Date().getTime() - config.loadingFlagTimeoutInMillis - 1
@@ -170,7 +174,7 @@ describe("Timelines", () => {
       .then(() => {
         assert(res.json.called);
         assert.deepEqual(res.json.lastCall.args[0], {
-          tweets: sample2Tweets
+          tweets: sampleTweetsFormatted
         });
 
         assert(!res.status.called);
@@ -191,7 +195,7 @@ describe("Timelines", () => {
     });
 
     it("should return tweets if loading is turned on but loadingStarted is not defined", () => {
-      simple.mock(twitter, "getUserTimeline").resolveWith(sample2Tweets);
+      simple.mock(twitter, "getUserTimeline").resolveWith(sampleTweets);
       simple.mock(cache, "getStatusFor").resolveWith({
         loading: true
       });
@@ -200,7 +204,7 @@ describe("Timelines", () => {
       .then(() => {
         assert(res.json.called);
         assert.deepEqual(res.json.lastCall.args[0], {
-          tweets: sample2Tweets
+          tweets: sampleTweetsFormatted
         });
 
         assert(!res.status.called);
@@ -277,13 +281,13 @@ describe("Timelines", () => {
     });
 
     it("should return tweets if Twitter API call is successful", () => {
-      simple.mock(twitter, "getUserTimeline").resolveWith(sample2Tweets);
+      simple.mock(twitter, "getUserTimeline").resolveWith(sampleTweets);
 
       return timelines.handleGetTweetsRequest(req, res)
       .then(() => {
         assert(res.json.called);
         assert.deepEqual(res.json.lastCall.args[0], {
-          tweets: sample2Tweets
+          tweets: sampleTweetsFormatted
         });
 
         assert(twitter.getUserTimeline.called);
@@ -307,14 +311,14 @@ describe("Timelines", () => {
     });
 
     it("should return tweets even if there's no username status stored", () => {
-      simple.mock(twitter, "getUserTimeline").resolveWith(sample2Tweets);
+      simple.mock(twitter, "getUserTimeline").resolveWith(sampleTweets);
       simple.mock(cache, "getStatusFor").resolveWith(null);
 
       return timelines.handleGetTweetsRequest(req, res)
       .then(() => {
         assert(res.json.called);
         assert.deepEqual(res.json.lastCall.args[0], {
-          tweets: sample2Tweets
+          tweets: sampleTweetsFormatted
         });
 
         assert(!res.status.called);

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -11,7 +11,6 @@ const timelines = require("../../src/timelines");
 const formatter = require("../../src/timelines/data_formatter");
 const twitter = require("../../src/twitter");
 
-const sample2Tweets = require("./samples/tweets-2").data;
 const sample30Tweets = require("./samples/tweets-30").data;
 const sampleTweets = require("./samples/tweets-timeline").data;
 
@@ -331,7 +330,7 @@ describe("Timelines", () => {
 
     it("should transform username to lowercase", () => {
       req.query.username = "UPPERCASE";
-      simple.mock(twitter, "getUserTimeline").resolveWith(sample2Tweets);
+      simple.mock(twitter, "getUserTimeline").resolveWith(sampleTweets);
 
       return timelines.handleGetTweetsRequest(req, res)
       .then(() => {


### PR DESCRIPTION
## Description
Transforming data from _user-timeline_ API response to our custom format for returning in `get-tweets` endpoint response. 

## Motivation and Context
Twitter Service development

## How Has This Been Tested?
Tested with _@ mashable_ to catch an _images_ populate and also _@ SarahKSilverman_ to catch a _quoted_ get populated.

https://services-stage.risevision.com/twitter/get-tweets?companyId=cb73b359-b827-4e38-9893-9ee28d8e5676&username=mashable&count=10

https://services-stage.risevision.com/twitter/get-tweets?companyId=cb73b359-b827-4e38-9893-9ee28d8e5676&username=SarahKSilverman&count=10

Will also test with other accounts but this appears to be enough to validate. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
