### PR TITLE
Feature/get only latest tweets

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -124,7 +124,7 @@ const returnTweetsFromCache = (query, res) => {
 const requestRemoteUserTimeline = (query, res, credentials) => {
   return saveLoadingFlag(query, true)
   .then(() => {
-    return twitter.getUserTimeline(credentials, query.username)
+    return twitter.getUserTimeline(credentials, query)
     .then(timeline => {
       const formattedTimeline = formatter.getTimelineFormatted(timeline);
 

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -25,7 +25,7 @@ const verifyCredentials = credentials => {
 };
 
 const getUserTimeline = (credentials, query) => {
-  const { status, username } = query
+  const {status, username} = query
 
   const args = {
     screen_name: username,

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -25,7 +25,7 @@ const verifyCredentials = credentials => {
 };
 
 const getUserTimeline = (credentials, query) => {
-  const {status, username} = query
+  const {status, username} = query;
 
   const args = {
     screen_name: username,

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -24,7 +24,9 @@ const verifyCredentials = credentials => {
     });
 };
 
-const getUserTimeline = (credentials, username) => {
+const getUserTimeline = (credentials, query) => {
+  const { username } = query
+
   const args = {
     screen_name: username,
     count: numberOfCachedTweets,

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -25,13 +25,17 @@ const verifyCredentials = credentials => {
 };
 
 const getUserTimeline = (credentials, query) => {
-  const { username } = query
+  const { status, username } = query
 
   const args = {
     screen_name: username,
     count: numberOfCachedTweets,
     tweet_mode: 'extended'
   };
+
+  if (status.lastTweetId) {
+    args.since_id = status.lastTweetId;
+  }
 
   return invokeEndpoint(credentials, 'statuses/user_timeline', args);
 };

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -316,7 +316,7 @@ describe("Timelines", () => {
         });
 
         assert(twitter.getUserTimeline.called);
-        assert.equal(twitter.getUserTimeline.lastCall.args[1], "risevision");
+        assert.equal(twitter.getUserTimeline.lastCall.args[1].username, "risevision");
 
         assert(!res.status.called);
         assert(!res.send.called);
@@ -362,7 +362,7 @@ describe("Timelines", () => {
         assert(!res.send.called);
 
         assert(twitter.getUserTimeline.called);
-        assert.equal(twitter.getUserTimeline.lastCall.args[1], "risevision");
+        assert.equal(twitter.getUserTimeline.lastCall.args[1].username, "risevision");
       });
     });
 
@@ -375,7 +375,7 @@ describe("Timelines", () => {
         assert(res.json.called);
 
         assert(twitter.getUserTimeline.called);
-        assert.equal(twitter.getUserTimeline.lastCall.args[1], "uppercase");
+        assert.equal(twitter.getUserTimeline.lastCall.args[1].username, "uppercase");
 
         assert(!res.status.called);
         assert(!res.send.called);

--- a/test/unit/twitter.tests.js
+++ b/test/unit/twitter.tests.js
@@ -1,3 +1,5 @@
+/* eslint-disable init-declarations */
+
 const assert = require("assert");
 const simple = require("simple-mock");
 
@@ -66,7 +68,10 @@ describe("Twitter", () => {
     let query;
 
     beforeEach(() => {
-      query = { username: "risevision", status: {} };
+      query = {
+        username: "risevision",
+        status: {}
+      };
     });
 
     it("should request user timeline", () => {


### PR DESCRIPTION
## Description
Requests to Twitter API only latest tweets, not those already cached.

## Motivation and Context
Part of the service design.

## How Has This Been Tested?
Manual test with new tweets: 
https://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RISEVISION&count=100

Unit tests also added.

## Release Plan:
Not on production

#### Release Checklist Items Skipped?
N/A