### PR TITLE
Feature/add cache control header

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,13 +1,15 @@
 /* eslint-disable no-magic-numbers */
 
-const { HOURS, MINUTES } = require('./constants');
+const {HOURS, MINUTES} = require('./constants');
 
 module.exports = {
   defaultPort: 80,
   defaultTweetCount: 25,
   cacheExpirationInMillis: 4 * HOURS,
   loadingFlagTimeoutInMillis: 2 * MINUTES,
-  retryLoadInSeconds: 30, // client will be asked to retry after this time to see if loading flag has been cleared
+
+  /* client will be asked to retry after this time to see if loading flag has been cleared */
+  retryLoadInSeconds: 30,
   numberOfCachedTweets: 100,
   redisCacheHostname: "ts-redis-master",
   redisOtpHostname: "otp-redis-master"

--- a/src/config.js
+++ b/src/config.js
@@ -1,14 +1,13 @@
 /* eslint-disable no-magic-numbers */
 
-const SECONDS = 1000;
-const MINUTES = 60 * SECONDS;
-const HOURS = 60 * MINUTES;
+const { HOURS, MINUTES } = require('./constants');
 
 module.exports = {
   defaultPort: 80,
   defaultTweetCount: 25,
   cacheExpirationInMillis: 4 * HOURS,
   loadingFlagTimeoutInMillis: 2 * MINUTES,
+  retryLoadInSeconds: 30, // client will be asked to retry after this time to see if loading flag has been cleared
   numberOfCachedTweets: 100,
   redisCacheHostname: "ts-redis-master",
   redisOtpHostname: "otp-redis-master"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,13 @@
+/* eslint-disable no-magic-numbers */
+
+const SECONDS = 1000;
+const MINUTES = 60 * SECONDS;
+const HOURS = 60 * MINUTES;
+
 module.exports = {
+  SECONDS,
+  MINUTES,
+  HOURS,
   BAD_REQUEST_ERROR: 400,
   FORBIDDEN_ERROR: 403,
   CONFLICT_ERROR: 409,

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -89,22 +89,23 @@ const saveStatusValues = (query, timeline) => {
 }
 
 const getCacheExpirationInSeconds = (status) => {
-  if (status.loading) { // update already loading, return low expiration
+  // update already loading, return low expiration
+  if (status.loading) {
     return config.retryLoadInSeconds;
   }
 
   const expirationTimestamp = status.lastUpdated + config.cacheExpirationInMillis;
   let remainingMillis = expirationTimestamp - currentTimestamp();
-  remainingMillis = Math.max( remainingMillis, 0 );
+  remainingMillis = Math.max(remainingMillis, 0);
 
-  return Math.ceil( remainingMillis / SECONDS ) + 1;
+  return Math.ceil(remainingMillis / SECONDS) + 1;
 };
 
 const returnTimeline = (query, res, timeline) => {
   const expiration = getCacheExpirationInSeconds(query.status);
   const tweets = timeline.slice(0, query.count);
 
-  res.header("Cache-control", `private, max-age=${ expiration }`);
+  res.header("Cache-control", `private, max-age=${expiration}`);
 
   res.json({
     tweets,

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines, no-magic-numbers, max-statements */
+/* eslint-disable max-lines, no-magic-numbers, max-statements, no-extra-parens */
 
 const assert = require("assert");
 const simple = require("simple-mock");

--- a/test/unit/timelines_cache.tests.js
+++ b/test/unit/timelines_cache.tests.js
@@ -1,11 +1,11 @@
-/* eslint-disable max-lines, no-magic-numbers, max-statements */
+/* eslint-disable max-lines, no-magic-numbers, max-statements, no-extra-parens */
 
 const assert = require("assert");
 const simple = require("simple-mock");
 
 const cache = require('../../src/redis-cache/api');
 const oauthTokenProvider = require("../../src/redis-otp/api");
-const { SECONDS } = require("../../src/constants");
+const {SECONDS} = require("../../src/constants");
 const config = require("../../src/config");
 const timelines = require("../../src/timelines");
 const formatter = require("../../src/timelines/data_formatter");


### PR DESCRIPTION
## Description
Adds Cache-Control header to get-tweets response.

## Motivation and Context
Part of design. Based on this header the rise-data-twitter component will request updated data.

## How Has This Been Tested?
A request now contains Cache-Control header - https://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RiseVision&count=2

for example:
![cache-control](https://user-images.githubusercontent.com/33162690/76554199-124c1900-645b-11ea-8f6e-aae886d4e1d1.png)

The previous capture shows a 102 minute expiration.

Unit tests were also added / completed.

## Release Plan:
Not in production.

#### Release Checklist Items Skipped?
N/A
