### PR TITLE
return cached tweets if loading flag is on

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -55,6 +55,10 @@ const logAndSendError = (res, error, status) => {
   sendError(res, error.message, status);
 };
 
+const hasCachedTweets = (query) => {
+  return query.status.lastUpdated;
+};
+
 const handleAnotherRequestIsAlreadyLoadingUserTimeline = (query, res, credentials) => {
   const elapsed = currentTimestamp() - (query.status.loadingStarted || 0);
 
@@ -62,7 +66,9 @@ const handleAnotherRequestIsAlreadyLoadingUserTimeline = (query, res, credential
     return requestRemoteUserTimeline(query, res, credentials);
   }
 
-  // TODO check cached entries will be implemented in other card
+  if (hasCachedTweets(query)) {
+    return returnTweetsFromCache(query, res);
+  }
 
   sendError(res, CONFLICT_ERROR_MESSAGE, CONFLICT_ERROR);
 };


### PR DESCRIPTION
## Description
Return cached tweets if they are available when loading flag is on.

## Motivation and Context
Part of Twitter service design.

## How Has This Been Tested?
The loading flag was forced for a username. Then a request was done for that username and it returned the expected HTTP response:

![load-from-cache](https://user-images.githubusercontent.com/33162690/76563586-5516ec80-646d-11ea-889a-c44ddb6eb2ec.png)

The 30 seconds expiration indicates that the client should request the updated Tweets soon to get the updated tweet list.

## Release Plan:
Not on production.

#### Release Checklist Items Skipped?
N/A
