### PR TITLE
Feature/detect invalid username

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-      - run: npm test
+      - run: echo npm test
 
   build-image:
     docker: *DOCKERIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-      - run: echo npm test
+      - run: npm test
 
   build-image:
     docker: *DOCKERIMAGE

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,9 +10,13 @@ module.exports = {
   HOURS,
   BAD_REQUEST_ERROR: 400,
   FORBIDDEN_ERROR: 403,
+  NOT_FOUND_ERROR: 404,
   CONFLICT_ERROR: 409,
   CONFLICT_ERROR_MESSAGE: "Another request is already loading user timeline. Please retry in a few seconds.",
   SERVER_ERROR: 500,
   MEDIA_TYPE_IMAGE: "photo",
-  MEDIA_TYPE_ANIMATED_GIF: "animated_gif"
+  MEDIA_TYPE_ANIMATED_GIF: "animated_gif",
+
+  // Twitter API codes: https://developer.twitter.com/en/docs/basics/response-codes
+  TWITTER_API_RESOURCE_NOT_FOUND_CODE: 34
 };

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -9,7 +9,7 @@ const formatter = require('./data_formatter');
 
 const {
   BAD_REQUEST_ERROR, CONFLICT_ERROR, CONFLICT_ERROR_MESSAGE, FORBIDDEN_ERROR,
-  SERVER_ERROR, SECONDS
+  NOT_FOUND_ERROR, SERVER_ERROR, SECONDS
 } = constants;
 
 const validationErrorFor = message => Promise.reject(new Error(message));
@@ -52,7 +52,7 @@ const sendError = (res, message, status) => {
 const logAndSendError = (res, error, status) => {
   console.error(error);
 
-  sendError(res, error.message + ":" + error.code + ":" + JSON.stringify(error.errors), status);
+  sendError(res, error.message, status);
 };
 
 const hasCachedTweets = (query) => {
@@ -119,9 +119,16 @@ const returnTimeline = (query, res, timeline) => {
   });
 };
 
-const handleTwitterApiCallError = (res, error) => {
+const handleTwitterApiCallError = (res, query, error) => {
   if (twitter.isInvalidOrExpiredTokenError(error)) {
     return logAndSendError(res, error, FORBIDDEN_ERROR);
+  }
+
+  if (twitter.isInvalidUsernameError(error)) {
+    query.status.invalidUsername = true;
+
+    return saveStatus(query)
+    .then(() => logAndSendError(res, error, NOT_FOUND_ERROR));
   }
 
   logAndSendError(res, error, SERVER_ERROR);
@@ -157,7 +164,7 @@ const requestRemoteUserTimeline = (query, res, credentials) => {
     })
     .catch(error => {
       return saveLoadingFlag(query, false)
-      .then(() => handleTwitterApiCallError(res, error));
+      .then(() => handleTwitterApiCallError(res, query, error));
     });
   });
 };

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -52,7 +52,7 @@ const sendError = (res, message, status) => {
 const logAndSendError = (res, error, status) => {
   console.error(error);
 
-  sendError(res, error.message, status);
+  sendError(res, error.message + ":" + error.code + ":" + JSON.stringify(error.errors), status);
 };
 
 const hasCachedTweets = (query) => {

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -126,6 +126,7 @@ const handleTwitterApiCallError = (res, query, error) => {
 
   if (twitter.isInvalidUsernameError(error)) {
     query.status.invalidUsername = true;
+    query.status.lastUpdated = currentTimestamp();
 
     return saveStatus(query)
     .then(() => logAndSendError(res, error, NOT_FOUND_ERROR));

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -1,4 +1,6 @@
 const config = require('../config');
+const constants = require('../constants');
+
 const Twitter = require('twitter');
 const TwitterCredentials = require('./twitter-app-credentials');
 
@@ -54,8 +56,13 @@ const isInvalidOrExpiredTokenError = error => {
   return error.message && error.message === "Invalid or expired token.";
 };
 
+const isInvalidUsernameError = error => {
+  return error.code === constants.TWITTER_API_RESOURCE_NOT_FOUND_CODE;
+}
+
 module.exports = {
   isInvalidOrExpiredTokenError,
+  isInvalidUsernameError,
   getUserTimeline,
   verifyCredentials
 };

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -343,18 +343,21 @@ describe("Timelines", () => {
         assert(cache.saveStatus.calls[0].args[1].loading);
         assert(cache.saveStatus.calls[0].args[1].loadingStarted);
         assert(!cache.saveStatus.calls[0].args[1].invalidUsername);
+        assert(!cache.saveStatus.calls[0].args[1].lastUpdated);
 
         // Stopped loading
         assert.equal(cache.saveStatus.calls[1].args[0], "risevision");
         assert(!cache.saveStatus.calls[1].args[1].loading);
         assert(!cache.saveStatus.calls[1].args[1].loadingStarted);
         assert(!cache.saveStatus.calls[1].args[1].invalidUsername);
+        assert(!cache.saveStatus.calls[1].args[1].lastUpdated);
 
         // Username invalid set
         assert.equal(cache.saveStatus.calls[2].args[0], "risevision");
         assert(!cache.saveStatus.calls[2].args[1].loading);
         assert(!cache.saveStatus.calls[2].args[1].loadingStarted);
         assert(cache.saveStatus.calls[2].args[1].invalidUsername);
+        assert(cache.saveStatus.calls[2].args[1].lastUpdated);
       });
     });
 

--- a/test/unit/twitter.tests.js
+++ b/test/unit/twitter.tests.js
@@ -1,4 +1,4 @@
-/* eslint-disable init-declarations */
+/* eslint-disable init-declarations, no-magic-numbers */
 
 const assert = require("assert");
 const simple = require("simple-mock");
@@ -33,6 +33,30 @@ describe("Twitter", () => {
 
     it("should not recognize invalid or expired token error when there is no message string", () => {
       const result = twitter.isInvalidOrExpiredTokenError({});
+
+      assert(!result);
+    });
+  });
+
+  describe("isInvalidUsernameError", () => {
+    it("should recognize invalid username error", () => {
+      const result = twitter.isInvalidUsernameError({
+        code: 34
+      });
+
+      assert(result);
+    });
+
+    it("should not recognize invalid username error on other error code", () => {
+      const result = twitter.isInvalidUsernameError({
+        code: 10
+      });
+
+      assert(!result);
+    });
+
+    it("should not recognize invalid username error when there is no error code", () => {
+      const result = twitter.isInvalidUsernameError({});
 
       assert(!result);
     });


### PR DESCRIPTION
## Description
Detect invalid usernames.

## Motivation and Context
Part of design

## How Has This Been Tested?
Requesting an invalid username with a company for credentials should return a 404 error, for example:

https://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=xxdadfdadfadf&count=2

Inspecting the request shows the error code:

![invalid_user_response](https://user-images.githubusercontent.com/33162690/76634513-f785ad00-650b-11ea-827c-ea4f771de63d.png)

In the following PR the invalidUsername flag will be inspected 

Unit tests were added.

## Release Plan:
Not in production.

#### Release Checklist Items Skipped?
N/A
