### PR TITLE
Feature/consider invalid username

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -95,7 +95,7 @@ const saveStatusValues = (query, timeline) => {
 }
 
 const getCacheExpirationInSeconds = (status) => {
-  // update already loading, return low expiration
+  // updated data already loading, return low expiration
   if (status.loading) {
     return config.retryLoadInSeconds;
   }

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -247,6 +247,7 @@ describe("Timelines", () => {
         assert(cache.saveStatus.calls[0].args[1].loadingStarted);
         assert(!cache.saveStatus.calls[0].args[1].lastUpdated);
         assert(!cache.saveStatus.calls[0].args[1].lastTweetId);
+        assert(!cache.saveStatus.calls[0].args[1].invalidUsername);
 
         // Status updated
         assert.equal(cache.saveStatus.calls[1].args[0], "risevision");
@@ -254,6 +255,7 @@ describe("Timelines", () => {
         assert(cache.saveStatus.calls[1].args[1].loadingStarted);
         assert(cache.saveStatus.calls[1].args[1].lastUpdated);
         assert.equal(cache.saveStatus.calls[1].args[1].lastTweetId, "1");
+        assert(!cache.saveStatus.calls[1].args[1].invalidUsername);
 
         // Stopped loading
         assert.equal(cache.saveStatus.calls[2].args[0], "risevision");
@@ -261,6 +263,7 @@ describe("Timelines", () => {
         assert(!cache.saveStatus.calls[2].args[1].loadingStarted);
         assert(cache.saveStatus.calls[2].args[1].lastUpdated);
         assert.equal(cache.saveStatus.calls[2].args[1].lastTweetId, "1");
+        assert(!cache.saveStatus.calls[2].args[1].invalidUsername);
       });
     });
   });

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -324,7 +324,7 @@ describe("Timelines", () => {
     });
 
     it("should send not found error if username is not valid", () => {
-      const error = new Error("Username not found");
+      const error = new Error();
       error.code = constants.TWITTER_API_RESOURCE_NOT_FOUND_CODE;
 
       simple.mock(twitter, "getUserTimeline").rejectWith(error);
@@ -337,7 +337,7 @@ describe("Timelines", () => {
         assert.equal(res.status.lastCall.args[0], NOT_FOUND_ERROR);
 
         assert(res.send.called);
-        assert.equal(res.send.lastCall.args[0], "Username not found");
+        assert.equal(res.send.lastCall.args[0], "Username not found: 'risevision'");
 
         assert.equal(cache.saveStatus.callCount, 3);
 

--- a/test/unit/timelines_cache.tests.js
+++ b/test/unit/timelines_cache.tests.js
@@ -95,6 +95,27 @@ describe("Timelines / handleGetTweetsRequest / Cache", () => {
     });
   });
 
+  it("should clear invalidUsername flag when expiration has passed", () => {
+    simple.mock(cache, "getStatusFor").resolveWith({
+      loading: false,
+      lastUpdated: new Date().getTime() - config.cacheExpirationInMillis - 1,
+      invalidUsername: true
+    });
+
+    return timelines.handleGetTweetsRequest(req, res)
+    .then(() => {
+      assert(res.json.called);
+      assert.deepEqual(res.json.lastCall.args[0], {
+        tweets: sampleTweetsFormatted,
+        cached: false
+      });
+
+      assert(twitter.getUserTimeline.called);
+
+      assert(!cache.saveStatus.lastCall.args[1].invalidUsername);
+    });
+  });
+
   it("should get cached tweets if expiration has not passed", () => {
     simple.mock(cache, "getStatusFor").resolveWith({
       loading: false,


### PR DESCRIPTION
## Description
Consider invalidUsername flag when looking at cached data.

## Motivation and Context
Part of design, so requests for invalid usernames do not consume Twitter API quota.

Some code was refactored to avoid repetition.

## How Has This Been Tested?
Bad user test: https://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=sdfalfdsaljfajfddla%C3%B1f&count=2

Unit tests created for the new scenarios, and checks for already existing tests were complemented.

## Release Plan:
Not in production

#### Release Checklist Items Skipped?
N/A
