### PR TITLE
Fix/first request does not return full tweets

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -209,6 +209,14 @@ const handleGetUserTimelineResponse = (query, twitterResp) => {
   .then(() => formattedTimeline);
 };
 
+const returnRemoteUserTimeline = (query, res, timeline) => {
+  if (timeline.length < query.count) {
+    return returnTweetsFromCache(query, res);
+  }
+
+  return returnTimeline(query, res, timeline);
+};
+
 const requestRemoteUserTimeline = (query, res, credentials) => {
   const {companyId} = query;
 
@@ -223,7 +231,7 @@ const requestRemoteUserTimeline = (query, res, credentials) => {
       .then(formattedTimeline => {
         return saveLoadingFlag(query, false)
         .then(() => saveUserQuota(query, twitterResp))
-        .then(() => returnTimeline(query, res, formattedTimeline));
+        .then(() => returnRemoteUserTimeline(query, res, formattedTimeline));
       });
     })
     .catch(err => {

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -200,8 +200,7 @@ const returnTweetsFromCache = (query, res) => {
   });
 };
 
-const handleGetUserTimelineResponse = (query, twitterResp) => {
-  const timeline = twitterResp.data;
+const saveUserTimeline = (query, timeline) => {
   const formattedTimeline = formatter.getTimelineFormatted(timeline);
 
   return cache.saveTweets(query.username, formattedTimeline)
@@ -224,13 +223,13 @@ const requestRemoteUserTimeline = (query, res, credentials) => {
   .then(() => saveLoadingFlag(query, true))
   .then(() => {
     return twitter.getUserTimeline(credentials, query)
-    .then(twitterResp => {
-      logUserQuota(companyId, twitterResp.quota);
+    .then(resp => {
+      logUserQuota(companyId, resp.quota);
 
-      return handleGetUserTimelineResponse(query, twitterResp)
+      return saveUserTimeline(query, resp.data)
       .then(formattedTimeline => {
         return saveLoadingFlag(query, false)
-        .then(() => saveUserQuota(query, twitterResp))
+        .then(() => saveUserQuota(query, resp))
         .then(() => returnRemoteUserTimeline(query, res, formattedTimeline));
       });
     })

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -170,6 +170,8 @@ describe("Timelines", () => {
     });
 
     it("should return tweets if loading is turned on but it has expired", () => {
+      req.query.count = "3";
+
       simple.mock(twitter, "getUserTimeline").resolveWith({
         data: sampleTweets,
         quota: {}
@@ -231,6 +233,8 @@ describe("Timelines", () => {
     });
 
     it("should return tweets if loading is turned on but loadingStarted is not defined", () => {
+      req.query.count = "3";
+
       simple.mock(twitter, "getUserTimeline").resolveWith({
         data: sampleTweets,
         quota: {}
@@ -393,6 +397,8 @@ describe("Timelines", () => {
       });
 
       it("should return tweets if Twitter API call is successful", () => {
+        req.query.count = "3";
+
         return timelines.handleGetTweetsRequest(req, res)
         .then(() => {
           assert(res.json.called);
@@ -446,6 +452,8 @@ describe("Timelines", () => {
       });
 
       it("should return tweets even if there's no username status stored", () => {
+        req.query.count = "3";
+
         simple.mock(cache, "getStatusFor").resolveWith(null);
 
         return timelines.handleGetTweetsRequest(req, res)
@@ -465,6 +473,7 @@ describe("Timelines", () => {
       });
 
       it("should transform username to lowercase", () => {
+        req.query.count = "3";
         req.query.username = "UPPERCASE";
 
         return timelines.handleGetTweetsRequest(req, res)


### PR DESCRIPTION
## Description
If a remote request to Twitter API is done to get latest tweets, and it returns less entries than those requested by count parameter, use cache to get the full requested tweets.

## Motivation and Context
Otherwise, get-tweet requests may return less data than requested; and in some cases no data.

## How Has This Been Tested?
Tested against endpoint after expiration time has passed:https://services-stage.risevision.com/twitter/get-tweets?companyId=121ae986-1b89-40c8-b10b-a64c60fb9e03&username=RiseVision&count=2

Previously, this returned a wrong number of tweets when remote Tweet API access was used.

Additional tests created. Some tests were updated.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
      - Not in production
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
