### PR TITLE
Use presentationId and componentId for getTweets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,10 +7,7 @@
     "extends": "eslint:recommended",
     "parserOptions": {
       "esversion": 6,
-      "ecmaVersion": 9,
-      "ecmaFeatures": {
-        "experimentalObjectRestSpread": true
-      }
+      "ecmaVersion": 2018
     },
     "rules": {
         "accessor-pairs": "error",
@@ -90,7 +87,7 @@
         "lines-between-class-members": "error",
         "max-depth": "error",
         "max-len": "off",
-        "max-lines": "error",
+        "max-lines": ["error", {"max": 500}],
         "max-nested-callbacks": "error",
         "max-params": "error",
         "max-statements": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1628,6 +1628,19 @@
         "gtoken": "^4.1.0",
         "jws": "^4.0.0",
         "lru-cache": "^5.0.0"
+      },
+      "dependencies": {
+        "gtoken": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+          "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+          "requires": {
+            "gaxios": "^2.1.0",
+            "google-p12-pem": "^2.0.0",
+            "jws": "^4.0.0",
+            "mime": "^2.2.0"
+          }
+        }
       }
     },
     "google-p12-pem": {
@@ -1675,17 +1688,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "gtoken": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
-      "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
-      "requires": {
-        "gaxios": "^2.1.0",
-        "google-p12-pem": "^2.0.0",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
-      }
     },
     "har-schema": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "@google-cloud/storage": "^4.3.1",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "node-fetch": "^2.6.0",
     "redis": "^3.0.2",
     "redis-promise": "git+https://github.com/Rise-Vision/redis-promise.git#1.2.0",
     "twitter": "^1.7.1"
   },
   "resolutions": {
     "acorn": "^7.1.1",
-    "minimist": "^1.2.2"
+    "minimist": "^1.2.3"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -23,6 +23,7 @@ app.get('/twitter', function(req, res) {
 
 app.get("/twitter/verify-credentials", credentials.handleVerifyCredentialsRequest);
 app.get("/twitter/get-tweets", timelines.handleGetTweetsRequest);
+app.get("/twitter/get-presentation-tweets", timelines.handleGetPresentationTweetsRequest);
 
 const start = ()=>{
   server.listen(port, (err) => {

--- a/src/config.js
+++ b/src/config.js
@@ -16,5 +16,5 @@ module.exports = {
   redisCacheHostname: "ts-redis-master",
   redisOtpHostname: "otp-redis-master",
 
-  coreBaseUrl: "https://return-company-id-dot-rvacore-test.appspot.com/_ah/api/"
+  coreBaseUrl: "https://rvacore-test.appspot.com/_ah/api"
 };

--- a/src/config.js
+++ b/src/config.js
@@ -14,5 +14,7 @@ module.exports = {
   retryLoadInSeconds: 30,
   numberOfCachedTweets: 100,
   redisCacheHostname: "ts-redis-master",
-  redisOtpHostname: "otp-redis-master"
+  redisOtpHostname: "otp-redis-master",
+
+  coreBaseUrl: "https://return-company-id-dot-rvacore-test.appspot.com/_ah/api/"
 };

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,8 +1,6 @@
 const config = require("../config");
 const utils = require("../utils");
 
-const validationErrorFor = message => Promise.reject(new Error(message));
-
 const loadPresentation = presentationId => {
   const url = `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}`;
 
@@ -19,7 +17,7 @@ const loadPresentation = presentationId => {
       return resp.items[0];
     }
 
-    throw new Error("Invalid response");
+    throw Error("Invalid response");
   });
 };
 
@@ -33,11 +31,11 @@ const getPresentation = (presentationId, componentId) => {
     const username = component ? component.username : null;
 
     if (!companyId) {
-      return validationErrorFor("Invalid companyId in Presentation");
+      return utils.validationErrorFor("Invalid companyId in Presentation");
     }
 
     if (!username) {
-      return validationErrorFor("Invalid username in Presentation");
+      return utils.validationErrorFor("Invalid username in Presentation");
     }
 
     return {companyId, username};

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,12 +1,12 @@
-const fetch = require("node-fetch");
 const config = require("../config");
+const utils = require("../utils");
 
 const validationErrorFor = message => Promise.reject(new Error(message));
 
 const loadPresentation = presentationId => {
   const url = `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}`;
 
-  return fetch(url)
+  return utils.fetch(url)
   .then(resp => {
     if (resp.ok) {
       return resp.json();

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,49 @@
+const fetch = require("node-fetch");
+const config = require("../config");
+
+const validationErrorFor = message => Promise.reject(new Error(message));
+
+const loadPresentation = presentationId => {
+  const url = `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}`;
+
+  return fetch(url)
+  .then(resp => {
+    if (resp.ok) {
+      return resp.json();
+    }
+
+    throw Error(resp.statusText);
+  })
+  .then(resp => {
+    if (resp.items && resp.items.length > 0) {
+      return resp.items[0];
+    }
+
+    throw new Error("Invalid response");
+  });
+};
+
+const getPresentation = (presentationId, componentId) => {
+  return loadPresentation(presentationId)
+  .then(presentation => {
+    const companyId = presentation.companyId;
+    const data = JSON.parse(presentation.templateAttributeData || "{}");
+    const components = data.components || [];
+    const component = components.find(comp => comp.id === componentId);
+    const username = component ? component.username : null;
+
+    if (!companyId) {
+      return validationErrorFor("Invalid companyId in Presentation");
+    }
+
+    if (!username) {
+      return validationErrorFor("Invalid username in Presentation");
+    }
+
+    return {companyId, username};
+  });
+};
+
+module.exports = {
+  getPresentation
+};

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -8,34 +8,34 @@ const twitter = require('../twitter');
 const core = require('../core');
 const {currentTimestamp} = require('../utils');
 const formatter = require('./data_formatter');
+const utils = require('../utils');
 
 const {
   BAD_REQUEST_ERROR, CONFLICT_ERROR, CONFLICT_ERROR_MESSAGE, FORBIDDEN_ERROR,
   NOT_FOUND_ERROR, SERVER_ERROR, SECONDS, PERCENT
 } = constants;
 
-const validationErrorFor = message => Promise.reject(new Error(message));
 const quotaLimitError = {message: "Quota limit reached."};
 
 const validateQueryParams = (req) => {
   const {companyId, count, username} = req.query;
 
   if (!companyId) {
-    return validationErrorFor("Company id was not provided");
+    return utils.validationErrorFor("Company id was not provided");
   }
 
   if (!username) {
-    return validationErrorFor("Username was not provided");
+    return utils.validationErrorFor("Username was not provided");
   }
 
   if (count && !(/^\d+$/).test(count)) {
-    return validationErrorFor(`'count' is not a valid integer value: ${count}`);
+    return utils.validationErrorFor(`'count' is not a valid integer value: ${count}`);
   }
 
   const countNumber = count ? Number(count) : config.defaultTweetCount;
 
   if (countNumber < 1 || countNumber > config.numberOfCachedTweets) {
-    return validationErrorFor(`'count' is out of range: ${countNumber}`);
+    return utils.validationErrorFor(`'count' is out of range: ${countNumber}`);
   }
 
   return Promise.resolve({
@@ -282,11 +282,11 @@ const validatePresentationQueryParams = (req) => {
   const {presentationId, componentId} = req.query;
 
   if (!presentationId) {
-    return validationErrorFor("Presentation id was not provided");
+    return utils.validationErrorFor("Presentation id was not provided");
   }
 
   if (!componentId) {
-    return validationErrorFor("Component id was not provided");
+    return utils.validationErrorFor("Component id was not provided");
   }
 
   return Promise.resolve({...req.query});

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -304,7 +304,15 @@ const handleGetPresentationTweetsRequest = (req, res) => {
 
     return handleGetTweetsRequest(req, res);
   })
-  .catch(error => logAndSendError(res, error, BAD_REQUEST_ERROR));
+  .catch(error => {
+    if (error.message === "Not Found") {
+      logAndSendError(res, error, NOT_FOUND_ERROR);
+    } else if (error.message && error.message.indexOf("was not provided") >= 0) {
+      logAndSendError(res, error, BAD_REQUEST_ERROR);
+    } else {
+      logAndSendError(res, error, SERVER_ERROR);
+    }
+  });
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const nodeFetch = require("node-fetch");
+
 const currentTimestamp = () => Date.now();
 
 const deepClone = (obj) => {
@@ -6,5 +8,6 @@ const deepClone = (obj) => {
 
 module.exports = {
   currentTimestamp,
-  deepClone
+  deepClone,
+  fetch: nodeFetch
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 const nodeFetch = require("node-fetch");
 
 const currentTimestamp = () => Date.now();
+const validationErrorFor = message => Promise.reject(new Error(message));
 
 const deepClone = (obj) => {
   return JSON.parse(JSON.stringify(obj));
@@ -8,6 +9,7 @@ const deepClone = (obj) => {
 
 module.exports = {
   currentTimestamp,
+  validationErrorFor,
   deepClone,
   fetch: nodeFetch
 };

--- a/test/unit/core.tests.js
+++ b/test/unit/core.tests.js
@@ -1,0 +1,94 @@
+const assert = require("assert");
+const simple = require("simple-mock");
+
+const config = require("../../src/config");
+const utils = require("../../src/utils");
+const core = require("../../src/core");
+
+describe("Core", () => {
+  const companyId = "testCompanyId";
+  const presentationId = "testPresentationId";
+  const componentId = "testComponentId";
+
+  beforeEach(() => {
+    config.coreBaseUrl = "https://rvacore-test.appspot.com/_ah/api";
+  });
+
+  afterEach(() => {
+    simple.restore();
+  });
+
+  describe("getPresentation", () => {
+    it("should succeed if presentation data is complete", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: [
+        {
+          companyId,
+          templateAttributeData: `{"components":[{"id":"${componentId}","username":"cnn","maxitems":10}]}`
+        }
+        ]})
+      });
+
+      core.getPresentation(presentationId, componentId)
+      .then(presentation => {
+        assert.equal(utils.fetch.lastCall.args[0], `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}`);
+        assert.equal(presentation.companyId, companyId);
+        assert.equal(presentation.username, "cnn");
+        done();
+      })
+    });
+
+    it("should reject if failure response is received", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: false,
+        statusText: "Not Found"
+      });
+
+      core.getPresentation(presentationId, componentId)
+      .catch(err => {
+        assert.equal(err.message, "Not Found");
+        done();
+      })
+    });
+
+    it("should reject if empty response is received", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: []})
+      });
+
+      core.getPresentation(presentationId, componentId)
+      .catch(err => {
+        assert.equal(err.message, "Invalid response");
+        done();
+      })
+    });
+
+    it("should reject if presentation data is not complete", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: [{}]})
+      });
+
+      core.getPresentation(presentationId, componentId)
+      .catch(err => {
+        assert.equal(err.message, "Invalid companyId in Presentation");
+        done();
+      })
+    });
+
+    it("should reject if presentation data is not complete", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: [{}]})
+      });
+
+      core.getPresentation(presentationId, componentId)
+      .catch(err => {
+        assert.equal(err.message, "Invalid companyId in Presentation");
+        done();
+      })
+    });
+  });
+});

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -536,4 +536,37 @@ describe("Timelines", () => {
       });
     });
   });
+
+  describe("handleGetPresentationTweetsRequest / validation", () => {
+    it("should reject if presentation id was not provided", () => {
+      req.query.presentationId = '';
+
+      return timelines.handleGetPresentationTweetsRequest(req, res)
+      .then(() => {
+        assert(!res.json.called);
+
+        assert(res.status.called);
+        assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+        assert(res.send.called);
+        assert.equal(res.send.lastCall.args[0], "Presentation id was not provided");
+      });
+    });
+
+    it("should reject if componentId was not provided", () => {
+      req.query.presentationId = 'test';
+      req.query.componentId = '';
+
+      return timelines.handleGetPresentationTweetsRequest(req, res)
+      .then(() => {
+        assert(!res.json.called);
+
+        assert(res.status.called);
+        assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+        assert(res.send.called);
+        assert.equal(res.send.lastCall.args[0], "Component id was not provided");
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description
First step towards migrating to using `presentationId` and `componentId. This adds a new endpoint but leaves the existing one untouched, in order to not affect other tasks.

Next set of PRs will include environment handling and caching (separate PRs)

## Motivation and Context
Part of our epic.

## How Has This Been Tested?
It can be validated here: https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=21c97752-0b8b-4a0c-852c-83c0471a3e00&componentId=rise-data-twitter-01

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
