### PR TITLE
Cache presentation data from Core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - setup_remote_docker
       - run: docker load < ./dockerImage.tar
       - run: gcloud docker -- push ${DOCKER_IMAGE_NAME}
-      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
+      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'","env":[{"name":"NODE_ENV","value":"ignore"}]}]}}}}'
 
   deploy-production:
     docker: *DOCKERIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - setup_remote_docker
       - run: docker load < ./dockerImage.tar
       - run: gcloud docker -- push ${DOCKER_IMAGE_NAME}
-      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
+      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'","env":[{"name":"NODE_ENV","value":"test"}]}]}}}}'
 
   deploy-production:
     docker: *DOCKERIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - setup_remote_docker
       - run: docker load < ./dockerImage.tar
       - run: gcloud docker -- push ${DOCKER_IMAGE_NAME}
-      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'","env":[{"name":"NODE_ENV","value":"test"}]}]}}}}'
+      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
 
   deploy-production:
     docker: *DOCKERIMAGE

--- a/package-lock.json
+++ b/package-lock.json
@@ -2522,6 +2522,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-hash": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
+      "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.0",
+    "object-hash": "^2.0.3",
     "redis": "^3.0.2",
     "redis-promise": "git+https://github.com/Rise-Vision/redis-promise.git#1.2.0",
     "twitter": "^1.7.1"

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-magic-numbers */
 
-const {HOURS, MINUTES} = require('./constants');
+const {HOURS, MINUTES} = require("./constants");
+
+const testServer = "rvacore-test";
+const prodServer = "rvaserver2";
+const currentServer = process.env.NODE_ENV === "test" ? testServer : prodServer;
 
 module.exports = {
   defaultPort: 80,
@@ -16,5 +20,5 @@ module.exports = {
   redisCacheHostname: "ts-redis-master",
   redisOtpHostname: "otp-redis-master",
 
-  coreBaseUrl: "https://rvacore-test.appspot.com/_ah/api"
+  coreBaseUrl: `https://${currentServer}.appspot.com/_ah/api`
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,12 @@
-/* eslint-disable no-magic-numbers */
+/* eslint-disable no-magic-numbers, no-warning-comments */
 
 const {HOURS, MINUTES} = require("./constants");
 
 const testServer = "rvacore-test";
-const prodServer = "rvaserver2";
-const currentServer = process.env.NODE_ENV === "test" ? testServer : prodServer;
+// const prodServer = "rvaserver2";
+
+// TODO: Until we setup production deployment, force using test server so we don't rely on NODE_ENV yet and cause issues with redis connections
+const currentServer = testServer;
 
 module.exports = {
   defaultPort: 80,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -71,7 +71,7 @@ const getCachedPresentationData = (presentationId, componentId) => {
   });
 };
 
-const saveCachedPresentationData = (presentationId, componentId, companyId, username) => {
+const saveCachedPresentationData = (presentationId, componentId, companyId, username) => { // eslint-disable-line max-params
   return cache.saveCompanyId(presentationId, companyId)
   .then(() => {
     return cache.saveUsername(presentationId, componentId, username);

--- a/src/redis-cache/api.js
+++ b/src/redis-cache/api.js
@@ -4,6 +4,8 @@ const redis = require("redis-promise");
 const statusKeyFor = username => `${username}:status`;
 const tweetsKeyFor = username => `${username}:tweets`;
 const userQuotaKeyFor = companyId => `${companyId}:quota:user-timeline`;
+const companyIdKeyFor = presentationId => `presentation:${presentationId}:companyId`;
+const usernameKeyFor = (presentationId, componentId) => `presentation:${presentationId}:component:${componentId}:username`;
 
 const parseJSON = (value) => {return value ? JSON.parse(value) : null};
 
@@ -50,11 +52,31 @@ const saveUserQuota = (companyId, quota) => {
   return redis.setString(userQuotaKeyFor(companyId), value);
 };
 
+const getCompanyIdFor = presentationId => {
+  return redis.getString(companyIdKeyFor(presentationId));
+}
+
+const saveCompanyId = (presentationId, companyId) => {
+  return redis.setString(companyIdKeyFor(presentationId), companyId);
+};
+
+const getUsernameFor = (presentationId, componentId) => {
+  return redis.getString(usernameKeyFor(presentationId, componentId));
+}
+
+const saveUsername = (presentationId, componentId, username) => {
+  return redis.setString(usernameKeyFor(presentationId, componentId), username);
+};
+
 module.exports = {
   getStatusFor,
   getTweetsFor,
   saveStatus,
   saveTweets,
   getUserQuotaFor,
-  saveUserQuota
+  saveUserQuota,
+  getCompanyIdFor,
+  saveCompanyId,
+  getUsernameFor,
+  saveUsername
 };

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -279,7 +279,7 @@ const handleGetTweetsRequest = (req, res) => {
 }
 
 const validatePresentationQueryParams = (req) => {
-  const {presentationId, componentId} = req.query;
+  const {presentationId, componentId, hash} = req.query;
 
   if (!presentationId) {
     return utils.validationErrorFor("Presentation id was not provided");
@@ -289,15 +289,19 @@ const validatePresentationQueryParams = (req) => {
     return utils.validationErrorFor("Component id was not provided");
   }
 
+  if (!hash) {
+    return utils.validationErrorFor("Hash was not provided");
+  }
+
   return Promise.resolve({...req.query});
 };
 
 const handleGetPresentationTweetsRequest = (req, res) => {
   return validatePresentationQueryParams(req)
   .then(params => {
-    const {presentationId, componentId} = params;
+    const {presentationId, componentId, hash} = params;
 
-    return core.getPresentation(presentationId, componentId);
+    return core.getPresentation(presentationId, componentId, hash);
   })
   .then(presentation => {
     req.query = {...req.query, ...presentation};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const hash = require("object-hash");
 const nodeFetch = require("node-fetch");
 
 const currentTimestamp = () => Date.now();
@@ -11,5 +12,6 @@ module.exports = {
   currentTimestamp,
   validationErrorFor,
   deepClone,
+  hash,
   fetch: nodeFetch
 };

--- a/test/unit/core.tests.js
+++ b/test/unit/core.tests.js
@@ -1,9 +1,11 @@
+/* eslint-disable no-magic-numbers */
 const assert = require("assert");
 const simple = require("simple-mock");
 
 const config = require("../../src/config");
 const utils = require("../../src/utils");
 const core = require("../../src/core");
+const cache = require("../../src/redis-cache/api");
 
 describe("Core", () => {
   const companyId = "testCompanyId";
@@ -12,6 +14,11 @@ describe("Core", () => {
 
   beforeEach(() => {
     config.coreBaseUrl = "https://rvacore-test.appspot.com/_ah/api";
+
+    simple.mock(cache, "getCompanyIdFor").resolveWith();
+    simple.mock(cache, "getUsernameFor").resolveWith();
+    simple.mock(cache, "saveCompanyId").resolveWith();
+    simple.mock(cache, "saveUsername").resolveWith();
   });
 
   afterEach(() => {
@@ -35,6 +42,11 @@ describe("Core", () => {
         assert.equal(utils.fetch.lastCall.args[0], `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}`);
         assert.equal(presentation.companyId, companyId);
         assert.equal(presentation.username, "cnn");
+
+        assert(cache.getCompanyIdFor.called);
+        assert.equal(cache.saveCompanyId.lastCall.args[1], companyId);
+        assert.equal(cache.saveUsername.lastCall.args[2], "cnn");
+
         done();
       })
     });
@@ -89,6 +101,104 @@ describe("Core", () => {
         assert.equal(err.message, "Invalid companyId in Presentation");
         done();
       })
+    });
+
+    describe("cache", () => {
+      const cachedPresentationId = "21c97752-0b8b-4a0c-852c-83c0471a3e00";
+      const cachedComponentId = "rise-data-twitter-01";
+      const cachedHash = "7e5f08005453cdc84155be70574531e271e05644";
+      const cachedCompanyId = "87977ab8-38b6-47fb-ad5e-256b8cc4b46d";
+      const cachedUsername = "cnn";
+
+      beforeEach(() => {
+        simple.mock(utils, "fetch").resolveWith({
+          ok: true,
+          json: () => ({items: [
+          {
+            companyId: cachedCompanyId,
+            templateAttributeData: `{"components":[{"id":"${cachedComponentId}","username":"newUsername","maxitems":10}]}`
+          }
+          ]})
+        });
+      });
+
+      it("should succeed if presentation data is cached", (done) => {
+        simple.mock(utils, "fetch").resolveWith();
+        simple.mock(cache, "getCompanyIdFor").resolveWith(cachedCompanyId);
+        simple.mock(cache, "getUsernameFor").resolveWith(cachedUsername);
+
+        core.getPresentation(cachedPresentationId, cachedComponentId, cachedHash)
+        .then(presentation => {
+          assert.equal(presentation.companyId, cachedCompanyId);
+          assert.equal(presentation.username, cachedUsername);
+
+          assert(!utils.fetch.called);
+
+          assert(cache.getCompanyIdFor.called);
+          assert(cache.getUsernameFor.called);
+          assert(!cache.saveCompanyId.called);
+          assert(!cache.saveUsername.called);
+
+          done();
+        })
+      });
+
+      it("should succeed if cache does not exist, but presentation data exists in Core", (done) => {
+        core.getPresentation(cachedPresentationId, cachedComponentId, cachedHash)
+        .then(presentation => {
+          assert.equal(presentation.companyId, cachedCompanyId);
+          assert.equal(presentation.username, "newUsername");
+
+          assert(utils.fetch.called);
+
+          assert(cache.getCompanyIdFor.called);
+          assert(cache.getUsernameFor.called);
+          assert(cache.saveCompanyId.called);
+          assert(cache.saveUsername.called);
+
+          done();
+        })
+      });
+
+      it("should succeed if hash does not match cached data, but presentation data exists in Core", (done) => {
+        simple.mock(cache, "getCompanyIdFor").resolveWith(cachedCompanyId);
+        simple.mock(cache, "getUsernameFor").resolveWith(cachedUsername);
+
+        core.getPresentation(cachedPresentationId, cachedComponentId, "invalidCache")
+        .then(presentation => {
+          assert.equal(presentation.companyId, cachedCompanyId);
+          assert.equal(presentation.username, "newUsername");
+
+          assert(utils.fetch.called);
+
+          assert(cache.getCompanyIdFor.called);
+          assert(cache.getUsernameFor.called);
+          assert(cache.saveCompanyId.called);
+          assert(cache.saveUsername.called);
+
+          done();
+        })
+      });
+
+      it("should fail if hash does not match cached data and presentation data does not exist in Core", (done) => {
+        simple.mock(utils, "fetch").resolveWith({ok: false, statusText: "Not Found"});
+        simple.mock(cache, "getCompanyIdFor").resolveWith(cachedCompanyId);
+        simple.mock(cache, "getUsernameFor").resolveWith(cachedUsername);
+
+        core.getPresentation(cachedPresentationId, cachedComponentId, "invalidCache")
+        .catch(err => {
+          assert(utils.fetch.called);
+
+          assert.equal(err.message, "Not Found");
+
+          assert(cache.getCompanyIdFor.called);
+          assert(cache.getUsernameFor.called);
+          assert(!cache.saveCompanyId.called);
+          assert(!cache.saveUsername.called);
+
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
These changes complete part 2 of 2 sets of changes required for implementation of not exposing company id in get tweets endpoint. Design doc [here](https://docs.google.com/document/d/1AigkbBu1aJSO4nrZjMpfOt6F76e43vgZPX_5JyPoSJw/edit#heading=h.4ve2jnvd4agp). Part 1 was PR #37  

Revised endpoint `get-presentation-tweets` is expecting _presentation id_, _component id_, and _hash_. The _hash_ is constructed with `presentationId` + `componentId` + `username` as a SHA1 hash value.

The endpoint calls Core to retrieve presentation in order to get company id which is required for the flow of verifying Twitter credentials and subsequently getting tweets. 

When presentation data is retrieved from Core, the data is cached to avoid hitting Core every time. In Redis the _presentationId_ -> _companyId_ and the _presentationId_ + _componentId_ -> _username_ associations are stored to retrieve this cached data. 

Force using Core `rvacore-test` server as Twitter Service has not been configured for production deployment. Temporarily avoiding conditional check of `NODE_ENV` when setting which Core server to use so to not impact Redis connections. An eventual production configuration will follow in future PRs that will establish `NODE_ENV` values per environment.  

A followup PR to this will deprecate `get-tweets` endpoint and will rename `get-presentation-tweets` to something suitable (or rename to `get-tweets`).

## Motivation and Context
Twitter Service Development - Do not expose company id in service endpoint request. 

## How Has This Been Tested?
Tested directly against the service with my staging company (has credentials authorized) and a test presentation. User is _mashable_. 

https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=7a910d41-419d-45fd-89fb-ffa697118163&componentId=rise-data-twitter-01&hash=A118A7D9C29A8A2057EE10172CEEDB853B7E5DFB

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Service is only running in staging cluster. Twitter component not used in real templates. Can release without any impact on users. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
