### PR TITLE
Add useDraft query param for get-presentation-tweets endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,7 @@
         "max-len": "off",
         "max-lines": ["error", {"max": 500}],
         "max-nested-callbacks": "error",
-        "max-params": "error",
+        "max-params": ["error", 4],
         "max-statements": "error",
         "max-statements-per-line": "off",
         "multiline-comment-style": "off",

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -279,7 +279,7 @@ const handleGetTweetsRequest = (req, res) => {
 }
 
 const validatePresentationQueryParams = (req) => {
-  const {presentationId, componentId, hash} = req.query;
+  const {presentationId, componentId, hash, useDraft} = req.query;
 
   if (!presentationId) {
     return utils.validationErrorFor("Presentation id was not provided");
@@ -293,15 +293,19 @@ const validatePresentationQueryParams = (req) => {
     return utils.validationErrorFor("Hash was not provided");
   }
 
+  if (!useDraft) {
+    return utils.validationErrorFor("Use Draft was not provided");
+  }
+
   return Promise.resolve({...req.query});
 };
 
 const handleGetPresentationTweetsRequest = (req, res) => {
   return validatePresentationQueryParams(req)
   .then(params => {
-    const {presentationId, componentId, hash} = params;
+    const {presentationId, componentId, hash, useDraft} = params;
 
-    return core.getPresentation(presentationId, componentId, hash);
+    return core.getPresentation(presentationId, componentId, hash, useDraft);
   })
   .then(presentation => {
     req.query = {...req.query, ...presentation};

--- a/test/unit/core.tests.js
+++ b/test/unit/core.tests.js
@@ -11,6 +11,7 @@ describe("Core", () => {
   const companyId = "testCompanyId";
   const presentationId = "testPresentationId";
   const componentId = "testComponentId";
+  const useDraft = false;
 
   beforeEach(() => {
     config.coreBaseUrl = "https://rvacore-test.appspot.com/_ah/api";
@@ -37,9 +38,9 @@ describe("Core", () => {
         ]})
       });
 
-      core.getPresentation(presentationId, componentId)
+      core.getPresentation(presentationId, componentId, null, useDraft)
       .then(presentation => {
-        assert.equal(utils.fetch.lastCall.args[0], `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}`);
+        assert.equal(utils.fetch.lastCall.args[0], `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}&useDraft=false`);
         assert.equal(presentation.companyId, companyId);
         assert.equal(presentation.username, "cnn");
 
@@ -57,7 +58,7 @@ describe("Core", () => {
         statusText: "Not Found"
       });
 
-      core.getPresentation(presentationId, componentId)
+      core.getPresentation(presentationId, componentId, null, useDraft)
       .catch(err => {
         assert.equal(err.message, "Not Found");
         done();
@@ -70,7 +71,7 @@ describe("Core", () => {
         json: () => ({items: []})
       });
 
-      core.getPresentation(presentationId, componentId)
+      core.getPresentation(presentationId, componentId, null, useDraft)
       .catch(err => {
         assert.equal(err.message, "Invalid response");
         done();
@@ -83,20 +84,7 @@ describe("Core", () => {
         json: () => ({items: [{}]})
       });
 
-      core.getPresentation(presentationId, componentId)
-      .catch(err => {
-        assert.equal(err.message, "Invalid companyId in Presentation");
-        done();
-      })
-    });
-
-    it("should reject if presentation data is not complete", (done) => {
-      simple.mock(utils, "fetch").resolveWith({
-        ok: true,
-        json: () => ({items: [{}]})
-      });
-
-      core.getPresentation(presentationId, componentId)
+      core.getPresentation(presentationId, componentId, null, useDraft)
       .catch(err => {
         assert.equal(err.message, "Invalid companyId in Presentation");
         done();

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -568,5 +568,39 @@ describe("Timelines", () => {
         assert.equal(res.send.lastCall.args[0], "Component id was not provided");
       });
     });
+
+    it("should reject if hash was not provided", () => {
+      req.query.presentationId = 'test';
+      req.query.componentId = 'test';
+      req.query.hash = '';
+
+      return timelines.handleGetPresentationTweetsRequest(req, res)
+        .then(() => {
+          assert(!res.json.called);
+
+          assert(res.status.called);
+          assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+          assert(res.send.called);
+          assert.equal(res.send.lastCall.args[0], "Hash was not provided");
+        });
+    });
+
+    it("should reject if useDraft was not provided", () => {
+      req.query.presentationId = 'test';
+      req.query.componentId = 'test';
+      req.query.hash = 'test';
+
+      return timelines.handleGetPresentationTweetsRequest(req, res)
+        .then(() => {
+          assert(!res.json.called);
+
+          assert(res.status.called);
+          assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+          assert(res.send.called);
+          assert.equal(res.send.lastCall.args[0], "Use Draft was not provided");
+        });
+    });
   });
 });


### PR DESCRIPTION
## Description
Implement a new required query param `useDraft` for `get-presentation-tweets` endpoint 

Apply `useDraft` as query param when making request to Core for retrieving presentation data. 

## Motivation and Context
This is part 1 of 2 changes to support Twitter Component running on Preview vs. Display. 

When running on Preview, our Service requires _revised_ (aka draft) presentation data to ensure it leverages the latest unpublished template attribute data. This is acquired by `useDraft` with a value of `true` in the Core request. 

When running on a Display, our our Service requires _published_ presentation data to ensure it leverages only the published template attribute data. This is acquired by `useDraft` with a value of `false` in the Core request.

## How Has This Been Tested?
Published: (username is CNN) 
https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=255d7a95-b6fb-4324-89b4-84fb661a7edb&componentId=rise-data-twitter-01&hash=test3&useDraft=false

Unpublished: (username is mashable)
https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=255d7a95-b6fb-4324-89b4-84fb661a7edb&componentId=rise-data-twitter-01&hash=test4&useDraft=true

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
