### PR TITLE
Get username value from blueprint when not available in presentation data

### DIFF
--- a/src/blueprint/index.js
+++ b/src/blueprint/index.js
@@ -1,0 +1,31 @@
+const config = require("../config");
+const utils = require("../utils");
+
+const load = (productCode) => {
+  const url = config.coreBlueprintUrl.replace('PRODUCT_CODE', productCode);
+
+  return utils.fetch(url)
+    .then(resp => {
+      if (resp.ok) {
+        return resp.json();
+      }
+
+      throw Error(resp.statusText);
+    })
+    .then(blueprint => {
+      return blueprint;
+    });
+}
+
+const extractUsername = (blueprint, componentId) => {
+  const components = blueprint.components || [];
+  const component = components.find(comp => comp.id === componentId);
+  const attributes = component.attributes || "{}";
+
+  return attributes.username ? attributes.username.value : null;
+}
+
+module.exports = {
+  extractUsername,
+  load
+};

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,9 @@ const {HOURS, MINUTES} = require("./constants");
 const testServer = "rvacore-test";
 // const prodServer = "rvaserver2";
 
+// TODO: configure conditionally when NODE_ENV variables finalized
+const blueprintStage = "staging";
+
 // TODO: Until we setup production deployment, force using test server so we don't rely on NODE_ENV yet and cause issues with redis connections
 const currentServer = testServer;
 
@@ -22,5 +25,7 @@ module.exports = {
   redisCacheHostname: "ts-redis-master",
   redisOtpHostname: "otp-redis-master",
 
-  coreBaseUrl: `https://${currentServer}.appspot.com/_ah/api`
+  coreBaseUrl: `https://${currentServer}.appspot.com/_ah/api`,
+
+  coreBlueprintUrl: `https://widgets.risevision.com/${blueprintStage}/templates/PRODUCT_CODE/blueprint.json`
 };

--- a/test/unit/blueprint.tests.js
+++ b/test/unit/blueprint.tests.js
@@ -1,0 +1,62 @@
+const assert = require("assert");
+const simple = require("simple-mock");
+
+const config = require("../../src/config");
+const utils = require("../../src/utils");
+const blueprint = require("../../src/blueprint");
+
+const sampleBlueprint = require("./samples/blueprint").data;
+
+describe("Blueprint", () => {
+  const productCode = "abc123";
+
+  beforeEach(() => {
+    config.coreBlueprintUrl = "https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json";
+  });
+
+  afterEach(() => {
+    simple.restore();
+  });
+
+  describe("load", () => {
+    it("should configure url with product code and return JSON data when request successful", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => sampleBlueprint
+      });
+
+      blueprint.load(productCode)
+        .then(data => {
+          assert.equal(utils.fetch.lastCall.args[0], "https://widgets.risevision.com/staging/templates/abc123/blueprint.json");
+          assert.equal(data.width, "1920");
+          assert.equal(data.height, "1080");
+
+          done();
+        })
+    });
+
+    it("should reject if failure response is received", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: false,
+        statusText: "Not Found"
+      });
+
+      blueprint.load(productCode)
+        .catch(err => {
+          assert.equal(err.message, "Not Found");
+          done();
+        })
+    });
+  });
+
+  describe("extractUsername", () => {
+    it("should return the username value of component from blueprint", () => {
+      assert.equal(blueprint.extractUsername(sampleBlueprint, "rise-data-twitter-01"), "cnn");
+    });
+
+    it("should return null if missing information", () => {
+      assert.equal(blueprint.extractUsername({components: [{id: "rise-data-twitter-01"}]}, "rise-data-twitter-01"), null);
+    });
+  });
+
+});

--- a/test/unit/samples/blueprint.js
+++ b/test/unit/samples/blueprint.js
@@ -1,0 +1,25 @@
+module.exports = {
+  data: {
+    "width": "1920",
+    "height": "1080",
+    "playUntilDone": false,
+    "branding": false,
+    "components": [
+      {
+        "type": "rise-data-twitter",
+        "id": "rise-data-twitter-01",
+        "nonEditable": false,
+        "attributes": {
+          "username": {
+            "label": "template.twitter",
+            "value": "cnn"
+          },
+          "maxitems": {
+            "label": "template.twitter",
+            "value": "20"
+          }
+        }
+      }
+      ]
+  }
+}


### PR DESCRIPTION
## Description
When username is not available from Core presentation data, load template blueprint with product code received from presentation data.

With template blueprint data, extract the username value from the appropriate component based on component id.

## Motivation and Context
This is part 2 of 2 changes to support Twitter Component running on Preview vs. Display. 1st set of change are here - https://github.com/Rise-Vision/twitter-service/pull/39

When a template is initially selected by a user and they view it in Template Editor, there is no attribute data available. Hence, the presentation data from Core will not provide the required username needed for retrieving tweets. In this situation, we now fall back to checking `username` in template blueprint. 

## How Has This Been Tested?
Tested via Apps staging by selecting _Example Twitter Component_ template and not make any changes to settings. 

https://apps-stage-8.risevision.com/templates/edit/d0612f02-2dce-4c75-87bf-bdb3eb149258/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
