### PR TITLE
Deprecate previous endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,6 @@ app.get('/twitter', function(req, res) {
 });
 
 app.get("/twitter/verify-credentials", credentials.handleVerifyCredentialsRequest);
-app.get("/twitter/get-tweets", timelines.handleGetTweetsRequest);
 app.get("/twitter/get-presentation-tweets", timelines.handleGetPresentationTweetsRequest);
 
 const start = ()=>{

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -324,5 +324,6 @@ const handleGetPresentationTweetsRequest = (req, res) => {
 }
 
 module.exports = {
+  handleGetTweetsRequest,
   handleGetPresentationTweetsRequest
 };

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -324,6 +324,5 @@ const handleGetPresentationTweetsRequest = (req, res) => {
 }
 
 module.exports = {
-  handleGetTweetsRequest,
   handleGetPresentationTweetsRequest
 };


### PR DESCRIPTION
## Description
Deprecate previous `get-tweets` endpoint

## Motivation and Context
To keep our API clean

## How Has This Been Tested?
N/A

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
