### PR TITLE
Implement new endpoint to handle username param

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23,6 +23,7 @@ app.get('/twitter', function(req, res) {
 
 app.get("/twitter/verify-credentials", credentials.handleVerifyCredentialsRequest);
 app.get("/twitter/get-presentation-tweets", timelines.handleGetPresentationTweetsRequest);
+app.get("/twitter/get-tweets", timelines.handleGetTweetsEncryptedRequest);
 
 const start = ()=>{
   server.listen(port, (err) => {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -26,6 +26,12 @@ const loadPresentationWithoutDraft = (presentationId) => {
       throw Error("Invalid response");
     })
     .then(presentation => {
+      const companyId = presentation.companyId;
+
+      if (!companyId) {
+        return utils.validationErrorFor("Invalid companyId in Presentation");
+      }
+
       return {companyId: presentation.companyId};
     });
 };

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -312,7 +312,7 @@ const validateEncryptedQueryParams = (req) => {
   }
 
   if (!username) {
-    return utils.validationErrorFor("Encrypted username was not provided");
+    return utils.validationErrorFor("Username was not provided");
   }
 
   return Promise.resolve({...req.query});

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -300,6 +300,24 @@ const validatePresentationQueryParams = (req) => {
   return Promise.resolve({...req.query});
 };
 
+const validateEncryptedQueryParams = (req) => {
+  const {presentationId, componentId, username} = req.query;
+
+  if (!presentationId) {
+    return utils.validationErrorFor("Presentation id was not provided");
+  }
+
+  if (!componentId) {
+    return utils.validationErrorFor("Component id was not provided");
+  }
+
+  if (!username) {
+    return utils.validationErrorFor("Encrypted username was not provided");
+  }
+
+  return Promise.resolve({...req.query});
+};
+
 const handleGetPresentationTweetsRequest = (req, res) => {
   return validatePresentationQueryParams(req)
   .then(params => {
@@ -323,7 +341,33 @@ const handleGetPresentationTweetsRequest = (req, res) => {
   });
 }
 
+const handleGetTweetsEncryptedRequest = (req, res) => {
+  return validateEncryptedQueryParams(req)
+    .then(params => {
+      const {presentationId, componentId, username} = params;
+
+      // TODO: decrypt username
+
+      return core.getPresentationWithoutHash(presentationId, componentId, username);
+    })
+    .then(presentation => {
+      req.query = {...req.query, ...presentation};
+
+      return handleGetTweetsRequest(req, res);
+    })
+    .catch(error => {
+      if (error.message === "Not Found") {
+        logAndSendError(res, error, NOT_FOUND_ERROR);
+      } else if (error.message && error.message.indexOf("was not provided") >= 0) {
+        logAndSendError(res, error, BAD_REQUEST_ERROR);
+      } else {
+        logAndSendError(res, error, SERVER_ERROR);
+      }
+    });
+}
+
 module.exports = {
   handleGetTweetsRequest,
+  handleGetTweetsEncryptedRequest,
   handleGetPresentationTweetsRequest
 };

--- a/test/unit/core.tests.js
+++ b/test/unit/core.tests.js
@@ -16,6 +16,7 @@ describe("Core", () => {
   const componentId = "rise-data-twitter-01";
   const useDraft = false;
   const productCode = "abc123";
+  const username = "RiseVision";
 
   beforeEach(() => {
     config.coreBaseUrl = "https://rvacore-test.appspot.com/_ah/api";
@@ -29,6 +30,167 @@ describe("Core", () => {
 
   afterEach(() => {
     simple.restore();
+  });
+
+  describe("getPresentationWithoutHash", () => {
+    it("should succeed if presentation data is complete", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: [
+            {
+              companyId
+            }
+          ]})
+      });
+
+      core.getPresentationWithoutHash(presentationId, componentId, username)
+        .then(presentation => {
+          assert.equal(utils.fetch.lastCall.args[0], `${config.coreBaseUrl}/content/v0/presentation?id=${presentationId}&useDraft=false`);
+          assert.equal(presentation.companyId, companyId);
+          assert.equal(presentation.username, "RiseVision");
+
+          assert(cache.getCompanyIdFor.called);
+          assert.equal(cache.saveCompanyId.lastCall.args[1], companyId);
+          assert.equal(cache.saveUsername.lastCall.args[2], "RiseVision");
+
+          done();
+        })
+    });
+
+    it("should reject if failure response is received", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: false,
+        statusText: "Not Found"
+      });
+
+      core.getPresentationWithoutHash(presentationId, componentId, username)
+        .catch(err => {
+          assert.equal(err.message, "Not Found");
+          done();
+        })
+    });
+
+    it("should reject if empty response is received", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: []})
+      });
+
+      core.getPresentationWithoutHash(presentationId, componentId, username)
+        .catch(err => {
+          assert.equal(err.message, "Invalid response");
+          done();
+        })
+    });
+
+    it("should reject if presentation data is not complete", (done) => {
+      simple.mock(utils, "fetch").resolveWith({
+        ok: true,
+        json: () => ({items: [{}]})
+      });
+
+      core.getPresentationWithoutHash(presentationId, componentId, username)
+        .catch(err => {
+          assert.equal(err.message, "Invalid companyId in Presentation");
+          done();
+        })
+    });
+
+    describe("cache", () => {
+      const cachedPresentationId = "21c97752-0b8b-4a0c-852c-83c0471a3e00";
+      const cachedComponentId = "rise-data-twitter-01";
+      const cachedCompanyId = "87977ab8-38b6-47fb-ad5e-256b8cc4b46d";
+      const cachedUsername = "cnn";
+
+      beforeEach(() => {
+        simple.mock(utils, "fetch").resolveWith({
+          ok: true,
+          json: () => ({items: [
+              {
+                companyId: cachedCompanyId
+              }
+            ]})
+        });
+      });
+
+      it("should succeed if presentation data is cached", (done) => {
+        simple.mock(utils, "fetch").resolveWith();
+        simple.mock(cache, "getCompanyIdFor").resolveWith(cachedCompanyId);
+        simple.mock(cache, "getUsernameFor").resolveWith(cachedUsername);
+
+        core.getPresentationWithoutHash(cachedPresentationId, cachedComponentId, cachedUsername)
+          .then(presentation => {
+            assert.equal(presentation.companyId, cachedCompanyId);
+            assert.equal(presentation.username, cachedUsername);
+
+            assert(!utils.fetch.called);
+
+            assert(cache.getCompanyIdFor.called);
+            assert(cache.getUsernameFor.called);
+            assert(!cache.saveCompanyId.called);
+            assert(!cache.saveUsername.called);
+
+            done();
+          })
+      });
+
+      it("should succeed if cache does not exist, but presentation data exists in Core", (done) => {
+        core.getPresentationWithoutHash(cachedPresentationId, cachedComponentId, cachedUsername)
+          .then(presentation => {
+            assert.equal(presentation.companyId, cachedCompanyId);
+            assert.equal(presentation.username, cachedUsername);
+
+            assert(utils.fetch.called);
+
+            assert(cache.getCompanyIdFor.called);
+            assert(cache.getUsernameFor.called);
+            assert(cache.saveCompanyId.called);
+            assert(cache.saveUsername.called);
+
+            done();
+          })
+      });
+
+      it("should succeed if username does not match cached data, but presentation data exists in Core", (done) => {
+        simple.mock(cache, "getCompanyIdFor").resolveWith(cachedCompanyId);
+        simple.mock(cache, "getUsernameFor").resolveWith(cachedUsername);
+
+        core.getPresentationWithoutHash(cachedPresentationId, cachedComponentId, "newUsername")
+          .then(presentation => {
+            assert.equal(presentation.companyId, cachedCompanyId);
+            assert.equal(presentation.username, "newUsername");
+
+            assert(utils.fetch.called);
+
+            assert(cache.getCompanyIdFor.called);
+            assert(cache.getUsernameFor.called);
+            assert(cache.saveCompanyId.called);
+            assert(cache.saveUsername.called);
+
+            done();
+          })
+      });
+
+      it("should fail if username does not match cached data and presentation data does not exist in Core", (done) => {
+        simple.mock(utils, "fetch").resolveWith({ok: false, statusText: "Not Found"});
+        simple.mock(cache, "getCompanyIdFor").resolveWith(cachedCompanyId);
+        simple.mock(cache, "getUsernameFor").resolveWith(cachedUsername);
+
+        core.getPresentationWithoutHash(cachedPresentationId, cachedComponentId, "newUsername")
+          .catch(err => {
+            assert(utils.fetch.called);
+
+            assert.equal(err.message, "Not Found");
+
+            assert(cache.getCompanyIdFor.called);
+            assert(cache.getUsernameFor.called);
+            assert(!cache.saveCompanyId.called);
+            assert(!cache.saveUsername.called);
+
+            done();
+          });
+      });
+    });
   });
 
   describe("getPresentation", () => {

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -603,4 +603,54 @@ describe("Timelines", () => {
         });
     });
   });
+
+  describe("handleGetTweetsEncryptedRequest / validation", () => {
+    it("should reject if presentation id was not provided", () => {
+      req.query.presentationId = '';
+
+      return timelines.handleGetTweetsEncryptedRequest(req, res)
+        .then(() => {
+          assert(!res.json.called);
+
+          assert(res.status.called);
+          assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+          assert(res.send.called);
+          assert.equal(res.send.lastCall.args[0], "Presentation id was not provided");
+        });
+    });
+
+    it("should reject if componentId was not provided", () => {
+      req.query.presentationId = 'test';
+      req.query.componentId = '';
+
+      return timelines.handleGetTweetsEncryptedRequest(req, res)
+        .then(() => {
+          assert(!res.json.called);
+
+          assert(res.status.called);
+          assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+          assert(res.send.called);
+          assert.equal(res.send.lastCall.args[0], "Component id was not provided");
+        });
+    });
+
+    it("should reject if username was not provided", () => {
+      req.query.presentationId = 'test';
+      req.query.componentId = 'test';
+      req.query.username = '';
+
+      return timelines.handleGetTweetsEncryptedRequest(req, res)
+        .then(() => {
+          assert(!res.json.called);
+
+          assert(res.status.called);
+          assert.equal(res.status.lastCall.args[0], BAD_REQUEST_ERROR);
+
+          assert(res.send.called);
+          assert.equal(res.send.lastCall.args[0], "Username was not provided");
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Description
Provide new endpoint `get-tweets` with expected params `presentationId`, `componentId`, and  `username`. Also supports optional `count` param. 

## Motivation and Context
This is the initial implementation and logic for supporting an endpoint to get tweets that takes a username. Follow up PR will implement expecting the `username` encrypted and handle decrypting it via public/private keys. 

These changes have been required to account for an issue with `get-presentation-tweets` endpoint where a race condition is occurring between presentation data being saved to Core via Apps attribute editor changes, and retrieving presentation data from Core in the Service in order to obtain the component instance username (as well as company id). 

## How Has This Been Tested?
Unit test coverage as well as testing directly against service.

https://services-stage.risevision.com/twitter/get-tweets?presentationId=d50d2ddc-f347-48a2-b46d-ad24e3557806&componentId=rise-data-twitter-01&username=RiseVision&count=3

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
