### PR TITLE
Implement providing mock data based on 'demo' presentation id

### DIFF
--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -9,6 +9,7 @@ const core = require('../core');
 const {currentTimestamp} = require('../utils');
 const formatter = require('./data_formatter');
 const utils = require('../utils');
+const mockData = require('./mock-data');
 
 const {
   BAD_REQUEST_ERROR, CONFLICT_ERROR, CONFLICT_ERROR_MESSAGE, FORBIDDEN_ERROR,
@@ -278,6 +279,16 @@ const handleGetTweetsRequest = (req, res) => {
   .catch(error => logAndSendError(res, error, BAD_REQUEST_ERROR));
 }
 
+const handleDemoTweetsRequest = (res) => {
+  const tweets = mockData.tweets().slice();
+
+  res.header("Cache-control", `private, max-age=0`);
+
+  res.json({
+    tweets
+  });
+}
+
 const validatePresentationQueryParams = (req) => {
   const {presentationId, componentId, hash, useDraft} = req.query;
 
@@ -346,11 +357,20 @@ const handleGetTweetsEncryptedRequest = (req, res) => {
     .then(params => {
       const {presentationId, componentId, username} = params;
 
+      // for rise-data-twitter e2e purposes and creative local development purposes
+      if (presentationId === "demo") {
+        return {companyId: "demo"}
+      }
+
       // TODO: decrypt username
 
       return core.getPresentationWithoutHash(presentationId, componentId, username);
     })
     .then(presentation => {
+      if (presentation.companyId === "demo") {
+        return handleDemoTweetsRequest(res);
+      }
+
       req.query = {...req.query, ...presentation};
 
       return handleGetTweetsRequest(req, res);
@@ -367,6 +387,7 @@ const handleGetTweetsEncryptedRequest = (req, res) => {
 }
 
 module.exports = {
+  handleDemoTweetsRequest,
   handleGetTweetsRequest,
   handleGetTweetsEncryptedRequest,
   handleGetPresentationTweetsRequest

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -282,8 +282,6 @@ const handleGetTweetsRequest = (req, res) => {
 const handleDemoTweetsRequest = (res) => {
   const tweets = mockData.tweets().slice();
 
-  res.header("Cache-control", `private, max-age=0`);
-
   res.json({
     tweets
   });
@@ -367,7 +365,7 @@ const handleGetTweetsEncryptedRequest = (req, res) => {
       return core.getPresentationWithoutHash(presentationId, componentId, username);
     })
     .then(presentation => {
-      if (presentation.companyId === "demo") {
+      if (presentation.companyId && presentation.companyId === "demo") {
         return handleDemoTweetsRequest(res);
       }
 

--- a/src/timelines/mock-data.js
+++ b/src/timelines/mock-data.js
@@ -1,0 +1,47 @@
+const tweets = () => {
+  return [
+    {
+      "createdAt": "Mon Apr 27 13:37:00 +0000 2020",
+      "images": [],
+      "name": "Rise Vision",
+      "profilePicture": "https://pbs.twimg.com/profile_images/1218249445676126215/8Y-ewcXg_normal.png",
+      "quoted": null,
+      "screenName": "RiseVision",
+      "statistics": {
+        "likeCount": 0,
+        "retweetCount": 0
+      },
+      "text": "Have you considered using #DIYdigtialsignage for your business?\n\nBefore you move forward, read this blog post and make sure you've considered these things!\n\n👇\nhttps://t.co/h9ju67uJWM",
+      "user": {
+        "description": "Digital signage doesn’t have to be difficult 🙅‍♀️ We make it easy or your money back 💰 #RiseVision",
+        "followers": 3020,
+        "statuses": 5893
+      }
+    },
+    {
+      "createdAt": "Fri Apr 24 18:26:47 +0000 2020",
+      "images": [
+        "https://pbs.twimg.com/media/EWY5B4_WoAE_GqX?format=jpg&name=large",
+        "https://pbs.twimg.com/media/EWY5CcpXQAEX4iG?format=jpg&name=large"
+      ],
+      "name": "Rise Vision",
+      "profilePicture": "https://pbs.twimg.com/profile_images/1218249445676126215/8Y-ewcXg_normal.png",
+      "quoted": null,
+      "screenName": "RiseVision",
+      "statistics": {
+        "likeCount": 0,
+        "retweetCount": 2
+      },
+      "text": "Have you checked out the new #LightItBlue Template? \n\nAdd it to your #digitalsignage here: https://t.co/sQ7DgjLCSt\n\n🔵Check it out in action👇 https://t.co/DBe6H3fTT0",
+      "user": {
+        "description": "Digital signage doesn’t have to be difficult 🙅‍♀️ We make it easy or your money back 💰 #RiseVision",
+        "followers": 3020,
+        "statuses": 5893
+      }
+    }
+  ]
+}
+
+module.exports = {
+  tweets
+}

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -11,9 +11,11 @@ const timelines = require("../../src/timelines");
 const formatter = require("../../src/timelines/data_formatter");
 const twitter = require("../../src/twitter");
 const utils = require("../../src/utils");
+const mockData = require("../../src/timelines/mock-data");
 
 const sample30Tweets = require("./samples/tweets-30").data;
 const sampleTweets = require("./samples/tweets-timeline").data;
+const mockDataTweets = mockData.tweets();
 
 const sampleTweetsFormatted = formatter.getTimelineFormatted(sampleTweets);
 
@@ -52,6 +54,32 @@ describe("Timelines", () => {
 
   afterEach(() => {
     simple.restore();
+  });
+
+  describe("handleDemoTweetsRequest", () => {
+    it("should return mock data", () => {
+      timelines.handleDemoTweetsRequest(res);
+
+      assert(res.json.called);
+      assert.deepEqual(res.json.lastCall.args[0], {
+        tweets: mockDataTweets
+      });
+
+      assert.equal(res.header.callCount, 1);
+      assert(!res.status.called);
+      assert(!res.send.called);
+
+      assert.equal(res.header.lastCall.args[0], "Cache-control");
+
+      const header = res.header.lastCall.args[1];
+      assert(header);
+
+      const fragments = header.split("=");
+      assert.equal(fragments[0], "private, max-age");
+
+      const expiration = Number(fragments[1]);
+      assert.equal(expiration, 0);
+    });
   });
 
   describe("handleGetTweetsRequest / validation", () => {
@@ -653,4 +681,5 @@ describe("Timelines", () => {
         });
     });
   });
+
 });

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -65,20 +65,8 @@ describe("Timelines", () => {
         tweets: mockDataTweets
       });
 
-      assert.equal(res.header.callCount, 1);
       assert(!res.status.called);
       assert(!res.send.called);
-
-      assert.equal(res.header.lastCall.args[0], "Cache-control");
-
-      const header = res.header.lastCall.args[1];
-      assert(header);
-
-      const fragments = header.split("=");
-      assert.equal(fragments[0], "private, max-age");
-
-      const expiration = Number(fragments[1]);
-      assert.equal(expiration, 0);
     });
   });
 


### PR DESCRIPTION
## Description
Send mock data in response when request has presentationId value as `demo`.

Component id, username, and count will all be ignored. 

## Motivation and Context
This is to resolve rise-data-twitter e2e test infrastructure due to an actual presentation id not being associated with the rise-data-twitter e2e html page (its scheduled as a URL Item). The url item will have `&presentationId=demo` appended so the component requests to the service with that value and the service responds with mock data. 

## How Has This Been Tested?
Tested against service. 

https://services-stage.risevision.com/twitter/get-tweets?presentationId=demo&componentId=rise-data-twitter-01&username=toronto&count=3

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
