### PR TITLE
Remove get-tweets endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23,8 +23,7 @@ app.get('/twitter', function(req, res) {
 
 app.get("/twitter/verify-credentials", credentials.handleVerifyCredentialsRequest);
 app.get("/twitter/get-presentation-tweets", timelines.handleGetPresentationTweetsRequest);
-app.get("/twitter/get-tweets", timelines.handleGetTweetsEncryptedRequest);
-app.get("/twitter/get-tweets-secure", timelines.handleGetTweetsSecureEncryptedRequest);
+app.get("/twitter/get-tweets-secure", timelines.handleGetTweetsEncryptedRequest);
 
 const start = ()=>{
   server.listen(port, (err) => {

--- a/src/timelines/index.js
+++ b/src/timelines/index.js
@@ -373,38 +373,6 @@ const handleGetTweetsEncryptedRequest = (req, res) => {
         return {companyId: "demo"}
       }
 
-      return core.getPresentationWithoutHash(presentationId, componentId, username);
-    })
-    .then(presentation => {
-      if (presentation.companyId && presentation.companyId === "demo") {
-        return handleDemoTweetsRequest(res);
-      }
-
-      req.query = {...req.query, ...presentation};
-
-      return handleGetTweetsRequest(req, res);
-    })
-    .catch(error => {
-      if (error.message === "Not Found") {
-        logAndSendError(res, error, NOT_FOUND_ERROR);
-      } else if (error.message && error.message.indexOf("was not provided") >= 0) {
-        logAndSendError(res, error, BAD_REQUEST_ERROR);
-      } else {
-        logAndSendError(res, error, SERVER_ERROR);
-      }
-    });
-}
-
-const handleGetTweetsSecureEncryptedRequest = (req, res) => {
-  return validateEncryptedQueryParams(req)
-    .then(params => {
-      const {presentationId, componentId, username} = params;
-
-      // for rise-data-twitter e2e purposes and creative local development purposes
-      if (presentationId === "demo") {
-        return {companyId: "demo"}
-      }
-
       const decryptedUsername = decryptParam(username);
 
       return core.getPresentationWithoutHash(presentationId, componentId, decryptedUsername);
@@ -434,6 +402,5 @@ module.exports = {
   handleDemoTweetsRequest,
   handleGetTweetsRequest,
   handleGetTweetsEncryptedRequest,
-  handleGetTweetsSecureEncryptedRequest,
   handleGetPresentationTweetsRequest
 };


### PR DESCRIPTION
## Description
- Remove `get-tweets` endpoint 
- Rename `handleGetTweetsSecureEncryptedRequest ` to `handleGetTweetsEncryptedRequest `

## Motivation and Context
Code cleanup

## How Has This Been Tested?
Manually on stage-8 and with existing unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
