### PR TITLE
Deploy to production cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - setup_remote_docker
       - run: docker load < ./dockerImage.tar
       - run: gcloud docker -- push ${DOCKER_IMAGE_NAME}
-      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'","env":[{"name":"NODE_ENV","value":"ignore"}]}]}}}}'
+      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'","env":[{"name":"NODE_ENV","value":"test"}]}]}}}}'
 
   deploy-production:
     docker: *DOCKERIMAGE
@@ -86,7 +86,7 @@ jobs:
       - run: gcloud config set project $PROJECT_ID
       - run: gcloud --quiet container clusters get-credentials messaging-service-prod
       - run: echo "Releasing ${CIRCLE_SHA1}"
-      - run: echo NOT YET DEPLOYING TO STABLE !
+      - run: kubectl patch deployment twitter-service -p '{"spec":{"template":{"spec":{"containers":[{"name":"twitter-service","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'","env":[{"name":"NODE_ENV","value":"prod"}]}]}}}}'
 
 workflows:
   workflow1:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",
     "test": "eslint . && mocha -t 20000 -r test/mocha-env.js test/unit/** test/integration/**",
-    "dev": "TS_PORT=8080 NODE_ENV=test nodemon index.js",
+    "dev": "TS_PORT=8080 NODE_ENV=dev nodemon index.js",
     "start": "node index.js"
   },
   "repository": {

--- a/src/config.js
+++ b/src/config.js
@@ -21,5 +21,5 @@ module.exports = {
   redisCacheHostname: "ts-redis-master",
   redisOtpHostname: "otp-redis-master",
 
-  coreBaseUrl: `https://${currentServer}.appspot.com/_ah/api`,
+  coreBaseUrl: `https://${currentServer}.appspot.com/_ah/api`
 };

--- a/src/config.js
+++ b/src/config.js
@@ -3,13 +3,9 @@
 const {HOURS, MINUTES} = require("./constants");
 
 const testServer = "rvacore-test";
-// const prodServer = "rvaserver2";
+const prodServer = "rvaserver2";
 
-// TODO: configure conditionally when NODE_ENV variables finalized
-const blueprintStage = "staging";
-
-// TODO: Until we setup production deployment, force using test server so we don't rely on NODE_ENV yet and cause issues with redis connections
-const currentServer = testServer;
+const currentServer = process.env.NODE_ENV === "prod" ? prodServer : testServer;
 
 module.exports = {
   defaultPort: 80,
@@ -26,6 +22,4 @@ module.exports = {
   redisOtpHostname: "otp-redis-master",
 
   coreBaseUrl: `https://${currentServer}.appspot.com/_ah/api`,
-
-  coreBlueprintUrl: `https://widgets.risevision.com/${blueprintStage}/templates/PRODUCT_CODE/blueprint.json`
 };

--- a/src/redis-cache/index.js
+++ b/src/redis-cache/index.js
@@ -1,7 +1,7 @@
 const config = require("../config");
 const redis = require("redis-promise");
 
-const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : config.redisCacheHostname;
+const redisHost = process.env.NODE_ENV === "dev" ? "127.0.0.1" : config.redisCacheHostname;
 
 module.exports = {
   initdb(dbclient = null) {

--- a/src/redis-otp/datastore.js
+++ b/src/redis-otp/datastore.js
@@ -2,7 +2,7 @@ const config = require("../config");
 const util = require("util");
 const redis = require("redis");
 
-const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : config.redisOtpHostname;
+const redisHost = process.env.NODE_ENV === "dev" ? "127.0.0.1" : config.redisOtpHostname;
 
 let client = null;
 let promisified = ["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "exists", "incr"];


### PR DESCRIPTION
## Description
Update conditionals that are dependent on NODE_ENV with values 
- `dev`: local development
- `test`: messaging-service-staging cluster
- `prod`: messaging-service-prod cluster

These environments also dictate which Core presentation/content endpoint url to use. 

CCI config updated to deploy to production cluster and ensure staging and production deployments have the appropriate NODE_ENV value applied

## Motivation and Context
Twitter release

## How Has This Been Tested?
Validated all working as expected on apps staging at https://apps-stage-8.risevision.com/templates/edit/442f3ffd-ecb7-4c3c-958a-8401fcf2b4ae/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Validation on production will occur when all parts are deployed

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
