### PR TITLE
Ensure largest version of profile picture is provided

### DIFF
--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -73,13 +73,17 @@ const getTextField = (tweet) => {
   return null;
 };
 
+const getLargeProfileUrl = (profileUrl) => {
+  return profileUrl.includes("_normal") ? profileUrl.replace("_normal", "") : profileUrl;
+}
+
 const getRootFields = (tweet) => {
   const userFields = {};
 
   if ("user" in tweet) {
     userFields.name = "name" in tweet.user ? tweet.user.name : null;
     userFields.screenName = "screen_name" in tweet.user ? tweet.user.screen_name : null;
-    userFields.profilePicture = "profile_image_url_https" in tweet.user ? tweet.user.profile_image_url_https : null;
+    userFields.profilePicture = "profile_image_url_https" in tweet.user ? getLargeProfileUrl(tweet.user.profile_image_url_https) : null;
   } else {
     userFields.name = null;
     userFields.screenName = null;

--- a/src/timelines/mock-data.js
+++ b/src/timelines/mock-data.js
@@ -4,12 +4,12 @@ const tweets = () => {
       "createdAt": "Mon Apr 27 13:37:00 +0000 2020",
       "images": [],
       "name": "Rise Vision",
-      "profilePicture": "https://pbs.twimg.com/profile_images/1218249445676126215/8Y-ewcXg_normal.png",
+      "profilePicture": "https://pbs.twimg.com/profile_images/1218249445676126215/8Y-ewcXg.png",
       "quoted": {
         "createdAt": "Mon Apr 27 13:48:07 +0000 2020",
         "images": [],
         "name": "Donald J. Trump",
-        "profilePicture": "https://pbs.twimg.com/profile_images/874276197357596672/kUuht00m_normal.jpg",
+        "profilePicture": "https://pbs.twimg.com/profile_images/874276197357596672/kUuht00m.jpg",
         "quoted": null,
         "screenName": "realDonaldTrump",
         "statistics": {
@@ -42,7 +42,7 @@ const tweets = () => {
         "https://pbs.twimg.com/media/EWY5CcpXQAEX4iG?format=jpg&name=large"
       ],
       "name": "Rise Vision",
-      "profilePicture": "https://pbs.twimg.com/profile_images/1218249445676126215/8Y-ewcXg_normal.png",
+      "profilePicture": "https://pbs.twimg.com/profile_images/1218249445676126215/8Y-ewcXg.png",
       "quoted": null,
       "screenName": "RiseVision",
       "statistics": {

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -87,7 +87,7 @@ describe("Timelines Data Formatting", () => {
 
       assert.equal(formatted[0].name, sampleTweets[0].user.name);
       assert.equal(formatted[0].screenName, sampleTweets[0].user.screen_name);
-      assert.equal(formatted[0].profilePicture, sampleTweets[0].user.profile_image_url_https);
+      assert.equal(formatted[0].profilePicture, "https://pbs.twimg.com/profile_images/1145679135873933312/OF0s1_Pe.png");
       assert.equal(formatted[0].createdAt, sampleTweets[0].created_at);
       assert.equal(formatted[0].text, sampleTweets[0].full_text);
       assert.deepEqual(formatted[0].images, ["https://pbs.twimg.com/media/ERpd155WAAIbGuw?format=jpg&name=large"]);
@@ -199,7 +199,7 @@ describe("Timelines Data Formatting", () => {
 
       assert.equal(formatted[2].quoted.name, sampleTweets[2].quoted_status.user.name);
       assert.equal(formatted[2].quoted.screenName, sampleTweets[2].quoted_status.user.screen_name);
-      assert.equal(formatted[2].quoted.profilePicture, sampleTweets[2].quoted_status.user.profile_image_url_https);
+      assert.equal(formatted[2].quoted.profilePicture, "https://pbs.twimg.com/profile_images/1197533022263877635/JxM1Ba0d.jpg");
       assert.equal(formatted[2].quoted.createdAt, sampleTweets[2].quoted_status.created_at);
       assert.equal(formatted[2].quoted.text, sampleTweets[2].quoted_status.full_text);
       assert.deepEqual(formatted[2].images, []);


### PR DESCRIPTION
## Description
Remove __normal_ from the profile picture url so the largest size is targeted

## Motivation and Context
Creative need largest size for template development

## How Has This Been Tested?
Note: if validating yourself, be sure to use a handle you haven't used before so that service/component doesn't provide cached data. 

![image](https://user-images.githubusercontent.com/7407007/81333501-b5dc3300-9072-11ea-938b-54b91594cafe.png)

https://pbs.twimg.com/profile_images/935885263955546112/7lobzXaB.jpg

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
