### PR TITLE
Base invalid token detection on API code instead of message String

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,5 +20,6 @@ module.exports = {
   MEDIA_TYPE_ANIMATED_GIF: "animated_gif",
 
   // Twitter API codes: https://developer.twitter.com/en/docs/basics/response-codes
-  TWITTER_API_RESOURCE_NOT_FOUND_CODE: 34
+  TWITTER_API_RESOURCE_NOT_FOUND_CODE: 34,
+  TWITTER_API_INVALID_OR_EXPIRED_TOKEN: 89
 };

--- a/src/twitter/index.js
+++ b/src/twitter/index.js
@@ -69,7 +69,7 @@ const invokeEndpoint = (clientCredentials, endpoint, args) => {
 };
 
 const isInvalidOrExpiredTokenError = error => {
-  return error.message && error.message === "Invalid or expired token.";
+  return error.code === constants.TWITTER_API_INVALID_OR_EXPIRED_TOKEN;
 };
 
 const isQuotaLimitReachedError = error => {

--- a/test/unit/credentials.tests.js
+++ b/test/unit/credentials.tests.js
@@ -50,8 +50,11 @@ describe("Credentials", () => {
     });
 
     it("should reject if Twitter credentials are not valid", (done) => {
+      const error = new Error("Invalid or expired token");
+      error.code = constants.TWITTER_API_INVALID_OR_EXPIRED_TOKEN;
+
       simple.mock(db, "getCredentials").resolveWith({});
-      simple.mock(twitter, "verifyCredentials").rejectWith(new Error("Invalid or expired token."));
+      simple.mock(twitter, "verifyCredentials").rejectWith(error);
 
       credentials.handleVerifyCredentialsRequest(req, res)
       .then(() => {

--- a/test/unit/timelines.tests.js
+++ b/test/unit/timelines.tests.js
@@ -336,7 +336,10 @@ describe("Timelines", () => {
       });
 
       it("should send forbidden error if Twitter API returns invalid token", () => {
-        simple.mock(twitter, "getUserTimeline").rejectWith({error: new Error("Invalid or expired token."), quota: {}});
+        const error = new Error("Invalid or expired token.");
+        error.code = constants.TWITTER_API_INVALID_OR_EXPIRED_TOKEN;
+
+        simple.mock(twitter, "getUserTimeline").rejectWith({error, quota: {}});
 
         return timelines.handleGetTweetsRequest(req, res)
         .then(() => {

--- a/test/unit/twitter.tests.js
+++ b/test/unit/twitter.tests.js
@@ -6,6 +6,7 @@ const simple = require("simple-mock");
 const Twitter = require('twitter');
 const twitter = require("../../src/twitter");
 const config = require("../../src/config");
+const constants = require("../../src/constants");
 
 const sampleTweets = require("./samples/tweets-timeline").data;
 
@@ -17,21 +18,21 @@ describe("Twitter", () => {
   describe("isInvalidOrExpiredTokenError", () => {
     it("should recognize invalid or expired token error", () => {
       const result = twitter.isInvalidOrExpiredTokenError({
-        message: "Invalid or expired token."
+        code: constants.TWITTER_API_INVALID_OR_EXPIRED_TOKEN
       });
 
       assert(result);
     });
 
-    it("should not recognize invalid or expired token error on other message string", () => {
+    it("should not recognize invalid or expired token error on other error code", () => {
       const result = twitter.isInvalidOrExpiredTokenError({
-        message: "Another error."
+        code: 92
       });
 
       assert(!result);
     });
 
-    it("should not recognize invalid or expired token error when there is no message string", () => {
+    it("should not recognize invalid or expired token error when there is no code", () => {
       const result = twitter.isInvalidOrExpiredTokenError({});
 
       assert(!result);


### PR DESCRIPTION
## Description
When checking specifically for an invalid or expired token response error from API _verify-credentials_ endpoint, now ensuring to check for code `89` as defined in the API response codes documentation - https://developer.twitter.com/en/docs/basics/response-codes

## Motivation and Context
Previously checking the error response `message` was brittle as the API could change the message value. 

## How Has This Been Tested?
Unit tests. Smoke tested service working as expected on Apps staging. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
