### PR TITLE
Support full text from a retweet

### DIFF
--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -61,15 +61,38 @@ const getUserFields = (tweet) => {
   };
 };
 
-const getTextField = (tweet) => {
-  const data = "retweeted_status" in tweet ? tweet.retweeted_status : tweet;
+const getRetweetTextField = (tweet) => {
+  const data = tweet.retweeted_status;
+  let screenName = 'unknown';
+
+  if ("user" in data) {
+    if ("screen_name" in data.user) {
+      screenName = `@${data.user.screen_name}`
+    }
+  }
 
   if ("full_text" in data) {
-    return data.full_text;
+    return `RT ${screenName}: ${data.full_text}`;
   }
 
   if ("text" in data) {
-    return data.text;
+    return `RT ${screenName}: ${data.text}`;
+  }
+
+  return null;
+}
+
+const getTextField = (tweet) => {
+  if ("retweeted_status" in tweet) {
+    return getRetweetTextField(tweet);
+  }
+
+  if ("full_text" in tweet) {
+    return tweet.full_text;
+  }
+
+  if ("text" in tweet) {
+    return tweet.text;
   }
 
   return null;

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -62,12 +62,14 @@ const getUserFields = (tweet) => {
 };
 
 const getTextField = (tweet) => {
-  if ("full_text" in tweet) {
-    return tweet.full_text;
+  const data = "retweeted_status" in tweet ? tweet.retweeted_status : tweet;
+
+  if ("full_text" in data) {
+    return data.full_text;
   }
 
-  if ("text" in tweet) {
-    return tweet.text;
+  if ("text" in data) {
+    return data.text;
   }
 
   return null;

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -126,26 +126,36 @@ describe("Timelines Data Formatting", () => {
 
     it("should return 'full_text' from 'retweeted_status' if present", () => {
       const modifiedSampleTweets = utils.deepClone(sampleTweets),
+        name = "original tweeter",
         text = "original message";
 
       modifiedSampleTweets[0].retweeted_status = {
-        "full_text": text
+        "full_text": text,
+        "user": {
+          "screen_name": name
+        }
       };
 
       const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
 
-      assert(formatted[0].text === text);
+      assert(formatted[0].text === `RT @${name}: ${text}`);
     });
 
     it("should fallback on 'text' from 'retweeted_status' if 'full_text' not present", () => {
       const modifiedSampleTweets = utils.deepClone(sampleTweets),
+        name = "original tweeter",
         text = "original message";
 
-      modifiedSampleTweets[0].retweeted_status = {text};
+      modifiedSampleTweets[0].retweeted_status = {
+        text,
+        "user": {
+          "screen_name": name
+        }
+      };
 
       const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
 
-      assert(formatted[0].text === text);
+      assert(formatted[0].text === `RT @${name}: ${text}`);
     })
 
     it("should return an empty array for 'images' if required fields missing", () => {

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -124,6 +124,30 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].text === text);
     });
 
+    it("should return 'full_text' from 'retweeted_status' if present", () => {
+      const modifiedSampleTweets = utils.deepClone(sampleTweets),
+        text = "original message";
+
+      modifiedSampleTweets[0].retweeted_status = {
+        "full_text": text
+      };
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[0].text === text);
+    });
+
+    it("should fallback on 'text' from 'retweeted_status' if 'full_text' not present", () => {
+      const modifiedSampleTweets = utils.deepClone(sampleTweets),
+        text = "original message";
+
+      modifiedSampleTweets[0].retweeted_status = {text};
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[0].text === text);
+    })
+
     it("should return an empty array for 'images' if required fields missing", () => {
       // test for missing "extended_entities"
       let modifiedSampleTweets = utils.deepClone(sampleTweets);


### PR DESCRIPTION
## Description
Preventing a retweet text from being truncated by checking for existence of `retweeted_status` and if present then construct the text to provide from the `full_text` property of `retweeted_status`. 

Also injecting the usual retweet prefix including username from the `retweeted_status`. The text is constructed as so:

`RT @ __user__: __full text__`

If _full_text_ not present in `retweeted_status`, then it falls back on _text_

## Motivation and Context
We don't want to truncate any tweet text, regardless of being a regular tweet, retweet, or quoted tweet. 

## How Has This Been Tested?
Tested staging service on staging apps 8. Screenshots of example retweets below:

https://www.screencast.com/t/28Ih5ptExqw1
https://www.screencast.com/t/R8bqxCgV1qFq

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
