### PR TITLE
Remove Twitter API generated urls from quote tweets

### DIFF
--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -97,19 +97,15 @@ const getTextField = (tweet) => {
     return getRetweetTextField(tweet);
   }
 
-  let text = "";
-
   if ("full_text" in tweet) {
-    text = tweet.full_text;
-  } else if ("text" in tweet) {
-    text = tweet.text;
+    return getTextWithoutShortenedUrls(tweet.full_text);
   }
 
-  if (text && isQuotedTweet(tweet)) {
-    text = getTextWithoutShortenedUrls(text);
+  if ("text" in tweet) {
+    return getTextWithoutShortenedUrls(tweet.text);
   }
 
-  return text || null;
+  return null;
 };
 
 const getLargeProfileUrl = (profileUrl) => {

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -82,11 +82,11 @@ const getRetweetTextField = (tweet) => {
   }
 
   if ("full_text" in data) {
-    return `RT ${screenName}: ${getTextWithoutShortenedUrls(data.full_text)}`;
+    return `RT ${screenName}: ${data.full_text}`;
   }
 
   if ("text" in data) {
-    return `RT ${screenName}: ${getTextWithoutShortenedUrls(data.text)}`;
+    return `RT ${screenName}: ${data.text}`;
   }
 
   return null;
@@ -97,12 +97,14 @@ const getTextField = (tweet) => {
     return getRetweetTextField(tweet);
   }
 
+  const isQuote = isQuotedTweet(tweet);
+
   if ("full_text" in tweet) {
-    return getTextWithoutShortenedUrls(tweet.full_text);
+    return isQuote ? getTextWithoutShortenedUrls(tweet.full_text) : tweet.full_text;
   }
 
   if ("text" in tweet) {
-    return getTextWithoutShortenedUrls(tweet.text);
+    return isQuote ? getTextWithoutShortenedUrls(tweet.text) : tweet.text;
   }
 
   return null;

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -155,5 +155,7 @@ const getTimelineFormatted = (timeline) => {
 };
 
 module.exports = {
-  getTimelineFormatted
+  getQuoteTextWithoutLink,
+  getTimelineFormatted,
+  isQuotedTweet
 };

--- a/src/timelines/data_formatter.js
+++ b/src/timelines/data_formatter.js
@@ -65,15 +65,15 @@ const getUserFields = (tweet) => {
   };
 };
 
-const getQuoteTextWithoutLink = (text) => {
+const getTextWithoutShortenedUrls = (text) => {
   if (!text) {return null;}
 
-  return text.replace(/https:\/\/t.co\/[^\/]+$/, '').trim(); // eslint-disable-line no-useless-escape
+  return text.replace(/https:\/\/t.co\/\S+/gi, '').trim(); // eslint-disable-line no-useless-escape
 }
 
 const getRetweetTextField = (tweet) => {
   const data = tweet.retweeted_status;
-  let screenName = 'unknown';
+  let screenName = "unknown";
 
   if ("user" in data) {
     if ("screen_name" in data.user) {
@@ -82,11 +82,11 @@ const getRetweetTextField = (tweet) => {
   }
 
   if ("full_text" in data) {
-    return `RT ${screenName}: ${data.full_text}`;
+    return `RT ${screenName}: ${getTextWithoutShortenedUrls(data.full_text)}`;
   }
 
   if ("text" in data) {
-    return `RT ${screenName}: ${data.text}`;
+    return `RT ${screenName}: ${getTextWithoutShortenedUrls(data.text)}`;
   }
 
   return null;
@@ -106,7 +106,7 @@ const getTextField = (tweet) => {
   }
 
   if (text && isQuotedTweet(tweet)) {
-    text = getQuoteTextWithoutLink(text);
+    text = getTextWithoutShortenedUrls(text);
   }
 
   return text || null;
@@ -155,7 +155,7 @@ const getTimelineFormatted = (timeline) => {
 };
 
 module.exports = {
-  getQuoteTextWithoutLink,
+  getTextWithoutShortenedUrls,
   getTimelineFormatted,
   isQuotedTweet
 };

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -141,6 +141,17 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].text === null);
     });
 
+    it("should remove all shortened urls from the text", () => {
+      const modifiedSampleTweets = utils.deepClone(sampleTweets),
+        text = "original message";
+
+      modifiedSampleTweets[0].full_text = `${text} https://t.co/test1 https://t.co/test2 https://t.co/test3`;
+
+      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
+
+      assert(formatted[0].text === text);
+    });
+
     it("should fallback on 'text' if 'full_text' not present", () => {
       const modifiedSampleTweets = utils.deepClone(sampleTweets),
         text = "Testing fallback on text";
@@ -188,7 +199,7 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].text === `RT @${name}: ${text}`);
     });
 
-    it("should remove the quote link from the text if this is a quote tweet", () => {
+    it("should remove the shortened url from the text for quote tweets", () => {
       const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
 
       assert.equal(formatted[2].text, "Example quoted tweet️");
@@ -271,7 +282,7 @@ describe("Timelines Data Formatting", () => {
       assert.equal(formatted[2].quoted.screenName, sampleTweets[2].quoted_status.user.screen_name);
       assert.equal(formatted[2].quoted.profilePicture, "https://pbs.twimg.com/profile_images/1197533022263877635/JxM1Ba0d.jpg");
       assert.equal(formatted[2].quoted.createdAt, sampleTweets[2].quoted_status.created_at);
-      assert.equal(formatted[2].quoted.text, sampleTweets[2].quoted_status.full_text);
+      assert.equal(formatted[2].quoted.text, timelineFormatter.getTextWithoutShortenedUrls(sampleTweets[2].quoted_status.full_text));
       assert.deepEqual(formatted[2].images, []);
 
       assert(formatted[2].quoted.quoted === null);

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -18,6 +18,30 @@ describe("Timelines Data Formatting", () => {
     simple.restore();
   });
 
+  describe("isQuotedTweet", () => {
+    it("should return false when not a quote tweet", () => {
+      assert(!timelineFormatter.isQuotedTweet(sampleTweets[0]));
+    });
+
+    it("should return true when is a quote tweet", () => {
+      assert(timelineFormatter.isQuotedTweet(sampleTweets[2]));
+    });
+  });
+
+  describe("getQuoteTextWithoutLink", () => {
+    it("should return the text without the API shortened quote url at the end", () => {
+      assert.equal(timelineFormatter.getQuoteTextWithoutLink(sampleTweets[2].full_text), "Example quoted tweet️");
+    });
+
+    it("should return the text unchanged if the API did not add shortened quote url at the end", () => {
+      assert.equal(timelineFormatter.getQuoteTextWithoutLink(sampleTweets[0].full_text), sampleTweets[0].full_text);
+    });
+
+    it("should return the text unchanged if the url at the end is not an API shortened url", () => {
+      assert.equal(timelineFormatter.getQuoteTextWithoutLink(`${sampleTweets[0].full_text} https://test.com`), `${sampleTweets[0].full_text} https://test.com`);
+    });
+  });
+
   describe("getTimelineFormatted / statistics", () => {
     it("should populate statistics values", () => {
       const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -28,17 +28,23 @@ describe("Timelines Data Formatting", () => {
     });
   });
 
-  describe("getQuoteTextWithoutLink", () => {
-    it("should return the text without the API shortened quote url at the end", () => {
-      assert.equal(timelineFormatter.getQuoteTextWithoutLink(sampleTweets[2].full_text), "Example quoted tweet️");
+  describe("getTextWithoutShortenedUrls()", () => {
+    it("should return the text without the API shortened url at the end", () => {
+      assert.equal(timelineFormatter.getTextWithoutShortenedUrls(sampleTweets[2].full_text), "Example quoted tweet️");
     });
 
-    it("should return the text unchanged if the API did not add shortened quote url at the end", () => {
-      assert.equal(timelineFormatter.getQuoteTextWithoutLink(sampleTweets[0].full_text), sampleTweets[0].full_text);
+    it("should return the text without multiple shortened urls at the end", () => {
+      const text = "original message";
+
+      assert.equal(timelineFormatter.getTextWithoutShortenedUrls(`${text} https://t.co/TEST1 https://t.co/TEST2`), text);
+    });
+
+    it("should return the text unchanged if the API did not add shortened url at the end", () => {
+      assert.equal(timelineFormatter.getTextWithoutShortenedUrls(sampleTweets[0].full_text), sampleTweets[0].full_text);
     });
 
     it("should return the text unchanged if the url at the end is not an API shortened url", () => {
-      assert.equal(timelineFormatter.getQuoteTextWithoutLink(`${sampleTweets[0].full_text} https://test.com`), `${sampleTweets[0].full_text} https://test.com`);
+      assert.equal(timelineFormatter.getTextWithoutShortenedUrls(`${sampleTweets[0].full_text} https://test.com`), `${sampleTweets[0].full_text} https://test.com`);
     });
   });
 
@@ -148,13 +154,13 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].text === text);
     });
 
-    it("should return 'full_text' from 'retweeted_status' if present", () => {
+    it("should return 'full_text' from 'retweeted_status' if present and without shortened urls", () => {
       const modifiedSampleTweets = utils.deepClone(sampleTweets),
         name = "original tweeter",
         text = "original message";
 
       modifiedSampleTweets[0].retweeted_status = {
-        "full_text": text,
+        "full_text": `${text} https://t.co/TEST1 https://t.co/TEST2`,
         "user": {
           "screen_name": name
         }

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -156,7 +156,13 @@ describe("Timelines Data Formatting", () => {
       const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
 
       assert(formatted[0].text === `RT @${name}: ${text}`);
-    })
+    });
+
+    it("should remove the quote link from the text if this is a quote tweet", () => {
+      const formatted = timelineFormatter.getTimelineFormatted(sampleTweets);
+
+      assert.equal(formatted[2].text, "Example quoted tweet️");
+    });
 
     it("should return an empty array for 'images' if required fields missing", () => {
       // test for missing "extended_entities"

--- a/test/unit/timelines_formatting.tests.js
+++ b/test/unit/timelines_formatting.tests.js
@@ -141,17 +141,6 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].text === null);
     });
 
-    it("should remove all shortened urls from the text", () => {
-      const modifiedSampleTweets = utils.deepClone(sampleTweets),
-        text = "original message";
-
-      modifiedSampleTweets[0].full_text = `${text} https://t.co/test1 https://t.co/test2 https://t.co/test3`;
-
-      const formatted = timelineFormatter.getTimelineFormatted(modifiedSampleTweets);
-
-      assert(formatted[0].text === text);
-    });
-
     it("should fallback on 'text' if 'full_text' not present", () => {
       const modifiedSampleTweets = utils.deepClone(sampleTweets),
         text = "Testing fallback on text";
@@ -165,13 +154,13 @@ describe("Timelines Data Formatting", () => {
       assert(formatted[0].text === text);
     });
 
-    it("should return 'full_text' from 'retweeted_status' if present and without shortened urls", () => {
+    it("should return 'full_text' from 'retweeted_status' if present", () => {
       const modifiedSampleTweets = utils.deepClone(sampleTweets),
         name = "original tweeter",
         text = "original message";
 
       modifiedSampleTweets[0].retweeted_status = {
-        "full_text": `${text} https://t.co/TEST1 https://t.co/TEST2`,
+        "full_text": text,
         "user": {
           "screen_name": name
         }
@@ -282,7 +271,7 @@ describe("Timelines Data Formatting", () => {
       assert.equal(formatted[2].quoted.screenName, sampleTweets[2].quoted_status.user.screen_name);
       assert.equal(formatted[2].quoted.profilePicture, "https://pbs.twimg.com/profile_images/1197533022263877635/JxM1Ba0d.jpg");
       assert.equal(formatted[2].quoted.createdAt, sampleTweets[2].quoted_status.created_at);
-      assert.equal(formatted[2].quoted.text, timelineFormatter.getTextWithoutShortenedUrls(sampleTweets[2].quoted_status.full_text));
+      assert.equal(formatted[2].quoted.text, sampleTweets[2].quoted_status.full_text);
       assert.deepEqual(formatted[2].images, []);
 
       assert(formatted[2].quoted.quoted === null);


### PR DESCRIPTION
## Description
Populating text quote tweets with text that has all occurrences of Twitter API shortened urls in it removed. 

Example shortened url - `https://t.co/LA5tgQEtU8` 

The regular expression used `/https:\/\/t.co\/\S+/gi` is broken down as follows:

`/https:\/\/t.co\/\` - matching urls that start with https://t.co/
`S+/` - matches all non-whitespace characters (to the end of the url)
`gi` - matches all case insensitive occurrences

## Motivation and Context
This is to address issue https://github.com/Rise-Vision/rise-data-twitter/issues/36

For a quote tweet, a shortened url is appended which is a link to the quote. 

This url is irrelevant when displayed in a template and is creating visual pollution. It is not clickable and provides no value since the original tweet is displayed on screen.  

## How Has This Been Tested?
Staging service on Apps staging with presentation: https://apps-stage-8.risevision.com/templates/edit/8a88077f-a380-43e2-8e4a-24efe04c6009/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Sample screenshot:

Quote tweet - https://www.screencast.com/t/BQ3EdW2fZ

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
